### PR TITLE
docs: add maintainer and portfolio identity metadata

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+# Maintainer
+
+Apple MCPs is built and maintained by [Jonathan R. Reed](https://jonathanrreed.com/about/), an AI security and software builder in Dallas focused on LLM red teaming, local-first tools, secure deployment, and native macOS software.
+
+- [Apple MCPs case study](https://jonathanrreed.com/projects/apple-mcps/)
+- [Portfolio](https://jonathanrreed.com/)
+- [Other projects](https://jonathanrreed.com/projects/)
+- [GitHub profile](https://github.com/JonathanRReed)
+
+Security issues should follow [`SECURITY.md`](SECURITY.md). General contributions should follow [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/Apple-Tools-MCP/pyproject.toml
+++ b/Apple-Tools-MCP/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
+authors = [
+  { name = "Jonathan R. Reed" },
+]
 keywords = ["mcp", "model-context-protocol", "macos", "apple", "ai-agent", "automation"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -40,6 +43,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/JonathanRReed/Apple-MCPs"
+Documentation = "https://github.com/JonathanRReed/Apple-MCPs/tree/main/docs"
+Portfolio = "https://jonathanrreed.com/projects/apple-mcps/"
+Author = "https://jonathanrreed.com/about/"
 Repository = "https://github.com/JonathanRReed/Apple-MCPs"
 Changelog = "https://github.com/JonathanRReed/Apple-MCPs/blob/main/CHANGELOG.md"
 Issues = "https://github.com/JonathanRReed/Apple-MCPs/issues"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "Cite the exact Apple MCPs release or Git commit used."
+title: "Apple MCPs: Local Apple App Tools for AI Agents"
+type: software
+authors:
+  - family-names: Reed
+    given-names: "Jonathan R."
+repository-code: "https://github.com/JonathanRReed/Apple-MCPs"
+url: "https://jonathanrreed.com/projects/apple-mcps/"
+license: MIT
+abstract: >-
+  Apple MCPs is a local macOS workspace of Model Context Protocol servers for
+  Apple Mail, Calendar, Reminders, Messages, Contacts, Notes, Shortcuts, Files,
+  System, and Maps. The servers use structured tools, explicit safety modes,
+  local stdio by default, and native Apple application data stores.
+keywords:
+  - Model Context Protocol
+  - macOS
+  - local-first
+  - AI agents
+  - Apple automation


### PR DESCRIPTION
## What changed

- adds root software citation metadata with Jonathan R. Reed as maintainer
- adds a short maintainer file linking the case study, portfolio, project archive, and GitHub profile
- adds author, documentation, portfolio, and About links to the recommended `apple-tools-mcp` package metadata

## Scope

No server behavior, permissions, safety mode, generated artifact, protocol, or release workflow changed.

## Verification

- branch diff is limited to two metadata files and one `pyproject.toml` metadata block
- existing CI ignores Markdown-only changes, but the package metadata change would normally run the workspace gates
- those GitHub Actions runners remain unavailable because of the account billing or spending-limit state; no runtime test result is claimed
