### PR TITLE
Fix Calendar create/get/update/delete under write-only EventKit access

### DIFF
--- a/Apple-Calendar-MCP/src/apple_calendar_mcp/apple_pim_bridge.swift
+++ b/Apple-Calendar-MCP/src/apple_calendar_mcp/apple_pim_bridge.swift
@@ -446,7 +446,11 @@ struct ApplePIMBridge {
 
     static func deleteEvent(store: EKEventStore, eventID: String) throws -> BooleanMutationPayload {
         guard let event = store.event(withIdentifier: eventID) else {
-            return BooleanMutationPayload(deleted: false, object_id: eventID)
+            throw BridgeFailure(
+                errorCode: "EVENT_NOT_FOUND",
+                message: "No event matched '\(eventID)'.",
+                suggestion: "List calendar events first to discover valid ids."
+            )
         }
         try store.remove(event, span: .thisEvent, commit: true)
         return BooleanMutationPayload(deleted: true, object_id: eventID)

--- a/Apple-Calendar-MCP/src/apple_calendar_mcp/calendar_bridge.py
+++ b/Apple-Calendar-MCP/src/apple_calendar_mcp/calendar_bridge.py
@@ -72,7 +72,12 @@ class CalendarBridge:
         ]
 
     def get_event(self, event_id: str) -> EventDetail:
-        payload = self._run_helper("get-calendar-event", event_id)
+        try:
+            payload = self._run_helper("get-calendar-event", event_id)
+        except CalendarBridgeError as exc:
+            if not self._should_use_fallback(exc):
+                raise
+            payload = self._fallback_get_event(event_id)
         return self._normalize_detail(payload)
 
     def create_event(
@@ -98,7 +103,23 @@ class CalendarBridge:
         }
         if recurrence is not None:
             request["recurrence"] = recurrence
-        payload = self._run_helper("create-calendar-event", json.dumps(request))
+        try:
+            payload = self._run_helper("create-calendar-event", json.dumps(request))
+        except CalendarBridgeError as exc:
+            if not self._should_use_fallback(exc):
+                raise
+            # The identifier came from the JXA read fallback (a calendar NAME,
+            # not a real EKCalendar.calendarIdentifier), so the native helper
+            # can never resolve it. Create the event by name instead.
+            payload = self._fallback_create_event(
+                title=title,
+                calendar_id=calendar_id,
+                start_iso=start_iso,
+                end_iso=end_iso,
+                notes=notes,
+                location=location,
+                all_day=all_day,
+            )
         return self._normalize_detail(payload)
 
     def update_event(
@@ -131,11 +152,30 @@ class CalendarBridge:
             request["all_day"] = all_day
         if recurrence is not None:
             request["recurrence"] = recurrence
-        payload = self._run_helper("update-calendar-event", event_id, json.dumps(request))
+        try:
+            payload = self._run_helper("update-calendar-event", event_id, json.dumps(request))
+        except CalendarBridgeError as exc:
+            if not self._should_use_fallback(exc):
+                raise
+            payload = self._fallback_update_event(
+                event_id,
+                title=title,
+                calendar_id=calendar_id,
+                start_iso=start_iso,
+                end_iso=end_iso,
+                notes=notes,
+                location=location,
+                all_day=all_day,
+            )
         return self._normalize_detail(payload)
 
     def delete_event(self, event_id: str) -> bool:
-        payload = self._run_helper("delete-calendar-event", event_id)
+        try:
+            payload = self._run_helper("delete-calendar-event", event_id)
+        except CalendarBridgeError as exc:
+            if not self._should_use_fallback(exc):
+                raise
+            payload = self._fallback_delete_event(event_id)
         return bool(payload.get("deleted", False))
 
     def _run_helper(self, command: str, *args: str) -> dict[str, object]:
@@ -236,6 +276,20 @@ class CalendarBridge:
             "HELPER_EXECUTION_FAILED",
         }
 
+    def _should_use_fallback(self, error: CalendarBridgeError) -> bool:
+        # CALENDAR_NOT_FOUND / EVENT_NOT_FOUND on top of the read-fallback
+        # codes: when the native EventKit helper only has write-only access
+        # (no can_read_events), every id the caller ever saw came from the
+        # JXA read fallback below, i.e. a calendar NAME or a synthetic
+        # "applescript::..." event id, never a real EKCalendar/EKEvent
+        # identifier. The native helper can then never resolve it, no matter
+        # how valid the id is, so the same request has to be retried through
+        # the JXA fallback instead of surfacing a confusing "not found".
+        return self._should_use_read_fallback(error) or error.error_code in {
+            "CALENDAR_NOT_FOUND",
+            "EVENT_NOT_FOUND",
+        }
+
     def _helper_read_blocked(self) -> bool:
         try:
             payload = self.calendar_access_status()
@@ -324,6 +378,203 @@ function run(argv) {
 }
 """
         return self._run_jxa(script, start.isoformat(), end.isoformat(), calendar_id or "", str(limit), timeout=self._JXA_TIMEOUT_SECONDS)
+
+    # Shared by every fallback below: locate an event by the uid the JXA read
+    # fallback handed out (or, for delete/update called with a helper-issued
+    # "applescript::calendar::start::title" synthetic id, fall back to that
+    # composite match too), searching one named calendar first when known,
+    # otherwise every calendar.
+    _JXA_FIND_EVENT = """
+function findEventByUid(app, uid, calendarNameHint) {
+  const calendars = calendarNameHint
+    ? app.calendars.byName(calendarNameHint) ? [app.calendars.byName(calendarNameHint)] : []
+    : app.calendars();
+  for (const cal of calendars) {
+    const matches = cal.events.whose({uid: uid})();
+    if (matches.length > 0) {
+      return {calendar: cal, event: matches[0]};
+    }
+  }
+  if (uid.indexOf("applescript::") === 0) {
+    const parts = uid.split("::");
+    const calName = parts[1];
+    const startIso = parts[2];
+    const title = parts.slice(3).join("::");
+    const targets = calName ? [app.calendars.byName(calName)] : app.calendars();
+    for (const cal of targets) {
+      const matches = cal.events.whose({summary: title, startDate: new Date(startIso)})();
+      if (matches.length > 0) {
+        return {calendar: cal, event: matches[0]};
+      }
+    }
+  }
+  return null;
+}
+
+function eventRecord(cal, evt) {
+  const startDate = evt.startDate();
+  const endDate = evt.endDate();
+  return {
+    event_id: evt.uid(),
+    title: evt.summary() || "",
+    calendar_id: cal.name(),
+    calendar_name: cal.name(),
+    start: startDate.toISOString(),
+    end: endDate.toISOString(),
+    all_day: startDate.getHours() === 0 && startDate.getMinutes() === 0 &&
+      endDate.getHours() === 23 && endDate.getMinutes() === 59,
+    location: evt.location ? (evt.location() || null) : null,
+    notes: evt.description ? (evt.description() || null) : null
+  };
+}
+"""
+
+    def _fallback_get_event(self, event_id: str) -> dict[str, object]:
+        script = self._JXA_FIND_EVENT + """
+function run(argv) {
+  const app = Application("Calendar");
+  const found = findEventByUid(app, argv[0], "");
+  if (!found) {
+    return JSON.stringify({__error__: "EVENT_NOT_FOUND"});
+  }
+  return JSON.stringify(eventRecord(found.calendar, found.event));
+}
+"""
+        return self._run_jxa_event(script, event_id)
+
+    def _fallback_create_event(
+        self,
+        *,
+        title: str,
+        calendar_id: str,
+        start_iso: str,
+        end_iso: str,
+        notes: str | None,
+        location: str | None,
+        all_day: bool,
+    ) -> dict[str, object]:
+        script = self._JXA_FIND_EVENT + """
+function run(argv) {
+  const app = Application("Calendar");
+  const calName = argv[0];
+  const cal = app.calendars.byName(calName);
+  if (!cal || !cal.exists()) {
+    return JSON.stringify({__error__: "CALENDAR_NOT_FOUND"});
+  }
+  const newEvent = app.Event({
+    summary: argv[1],
+    startDate: new Date(argv[2]),
+    endDate: new Date(argv[3]),
+    location: argv[4],
+    description: argv[5]
+  });
+  cal.events.push(newEvent);
+  if (argv[6] === "true") {
+    newEvent.alldayEvent = true;
+  }
+  return JSON.stringify(eventRecord(cal, newEvent));
+}
+"""
+        return self._run_jxa_event(
+            script,
+            calendar_id,
+            title,
+            start_iso,
+            end_iso,
+            location or "",
+            notes or "",
+            "true" if all_day else "false",
+        )
+
+    def _fallback_update_event(
+        self,
+        event_id: str,
+        *,
+        title: str | None,
+        calendar_id: str | None,
+        start_iso: str | None,
+        end_iso: str | None,
+        notes: str | None,
+        location: str | None,
+        all_day: bool | None,
+    ) -> dict[str, object]:
+        fields = {
+            "title": title,
+            "calendar_id": calendar_id,
+            "start": start_iso,
+            "end": end_iso,
+            "notes": notes,
+            "location": location,
+            "all_day": all_day,
+        }
+        script = self._JXA_FIND_EVENT + """
+function run(argv) {
+  const app = Application("Calendar");
+  const eventId = argv[0];
+  const fields = JSON.parse(argv[1]);
+  const found = findEventByUid(app, eventId, "");
+  if (!found) {
+    return JSON.stringify({__error__: "EVENT_NOT_FOUND"});
+  }
+  let cal = found.calendar;
+  let evt = found.event;
+
+  const wantsMove = fields.calendar_id && fields.calendar_id !== cal.name();
+  if (wantsMove) {
+    const targetCal = app.calendars.byName(fields.calendar_id);
+    if (!targetCal || !targetCal.exists()) {
+      return JSON.stringify({__error__: "CALENDAR_NOT_FOUND"});
+    }
+    const moved = app.Event({
+      summary: fields.title !== null ? fields.title : (evt.summary() || ""),
+      startDate: fields.start !== null ? new Date(fields.start) : evt.startDate(),
+      endDate: fields.end !== null ? new Date(fields.end) : evt.endDate(),
+      location: fields.location !== null ? fields.location : (evt.location ? (evt.location() || "") : ""),
+      description: fields.notes !== null ? fields.notes : (evt.description ? (evt.description() || "") : "")
+    });
+    targetCal.events.push(moved);
+    if (fields.all_day !== null) {
+      moved.alldayEvent = fields.all_day;
+    }
+    cal.events.whose({uid: eventId})[0].delete();
+    return JSON.stringify(eventRecord(targetCal, moved));
+  }
+
+  if (fields.title !== null) { evt.summary = fields.title; }
+  if (fields.start !== null) { evt.startDate = new Date(fields.start); }
+  if (fields.end !== null) { evt.endDate = new Date(fields.end); }
+  if (fields.location !== null) { evt.location = fields.location; }
+  if (fields.notes !== null) { evt.description = fields.notes; }
+  if (fields.all_day !== null) { evt.alldayEvent = fields.all_day; }
+  return JSON.stringify(eventRecord(cal, evt));
+}
+"""
+        return self._run_jxa_event(script, event_id, json.dumps(fields))
+
+    def _fallback_delete_event(self, event_id: str) -> dict[str, object]:
+        script = self._JXA_FIND_EVENT + """
+function run(argv) {
+  const app = Application("Calendar");
+  const found = findEventByUid(app, argv[0], "");
+  if (!found) {
+    return JSON.stringify({__error__: "EVENT_NOT_FOUND"});
+  }
+  found.event.delete();
+  return JSON.stringify({deleted: true});
+}
+"""
+        return self._run_jxa_event(script, event_id)
+
+    def _run_jxa_event(self, script: str, *args: str) -> dict[str, object]:
+        payload = self._run_jxa(script, *args, timeout=self._JXA_TIMEOUT_SECONDS)
+        error_code = payload.get("__error__")
+        if error_code:
+            raise CalendarBridgeError(
+                str(error_code),
+                f"No matching calendar item found via the AppleScript fallback (id/name '{args[0] if args else ''}').",
+                "List calendars or events first to discover a valid current id.",
+            )
+        return payload
 
     def _fallback_events_payload(self, start_iso: str, end_iso: str, calendar_id: str | None = None, limit: int = 100) -> dict[str, object]:
         if calendar_id:

--- a/Apple-Calendar-MCP/tests/test_calendar_bridge.py
+++ b/Apple-Calendar-MCP/tests/test_calendar_bridge.py
@@ -34,12 +34,22 @@ def test_list_events_normalizes_event_ids(monkeypatch) -> None:
 
 
 def test_get_event_raises_when_missing(monkeypatch) -> None:
+    # EVENT_NOT_FOUND from the native helper now also retries through the JXA
+    # fallback (see test_get_event_falls_back_on_event_not_found below): under
+    # write-only Calendar access, EVERY id the caller ever saw came from that
+    # same fallback, so the native helper can never resolve one by identifier
+    # and would otherwise always raise a misleading EVENT_NOT_FOUND. A genuine
+    # miss must still surface as EVENT_NOT_FOUND once the fallback also fails.
     bridge = CalendarBridge(Path("/tmp/source.swift"), Path("/tmp/helper"))
 
     def fake_run_helper(command: str, *args: str) -> dict[str, object]:
         raise CalendarBridgeError("EVENT_NOT_FOUND", "missing")
 
+    def fake_run_jxa(script: str, *args: str, timeout: int | None = None) -> dict[str, object]:
+        return {"__error__": "EVENT_NOT_FOUND"}
+
     monkeypatch.setattr(bridge, "_run_helper", fake_run_helper)
+    monkeypatch.setattr(bridge, "_run_jxa", fake_run_jxa)
 
     try:
         bridge.get_event("event-123")
@@ -47,6 +57,90 @@ def test_get_event_raises_when_missing(monkeypatch) -> None:
         assert exc.error_code == "EVENT_NOT_FOUND"
     else:
         raise AssertionError("Expected CalendarBridgeError")
+
+
+def test_get_event_falls_back_on_event_not_found(monkeypatch) -> None:
+    # The concrete bug this closes: under write-only Calendar access, ids
+    # only ever come from the JXA read fallback (a calendar NAME plus the
+    # AppleScript event uid), so store.event(withIdentifier:) in the native
+    # Swift helper can never resolve them and always raises EVENT_NOT_FOUND,
+    # even for an id that is perfectly valid in the fallback's own world.
+    bridge = CalendarBridge(Path("/tmp/source.swift"), Path("/tmp/helper"))
+
+    def fake_run_helper(command: str, *args: str) -> dict[str, object]:
+        raise CalendarBridgeError("EVENT_NOT_FOUND", "missing")
+
+    def fake_run_jxa(script: str, *args: str, timeout: int | None = None) -> dict[str, object]:
+        return {
+            "event_id": "applescript-uid-1",
+            "title": "Fallback event",
+            "calendar_id": "Home",
+            "calendar_name": "Home",
+            "start": "2026-03-27T15:00:00+00:00",
+            "end": "2026-03-27T15:30:00+00:00",
+            "all_day": False,
+            "location": None,
+            "notes": None,
+        }
+
+    monkeypatch.setattr(bridge, "_run_helper", fake_run_helper)
+    monkeypatch.setattr(bridge, "_run_jxa", fake_run_jxa)
+
+    event = bridge.get_event("applescript-uid-1")
+
+    assert event.event_id == "applescript-uid-1"
+    assert event.calendar_name == "Home"
+
+
+def test_create_event_falls_back_when_calendar_id_is_a_name(monkeypatch) -> None:
+    # The exact repro Robin hit: create_event("Privat", ...) fails natively
+    # with CALENDAR_NOT_FOUND because "Privat" is a calendar NAME from the
+    # JXA list fallback, not a real EKCalendar.calendarIdentifier.
+    bridge = CalendarBridge(Path("/tmp/source.swift"), Path("/tmp/helper"))
+
+    def fake_run_helper(command: str, *args: str) -> dict[str, object]:
+        raise CalendarBridgeError("CALENDAR_NOT_FOUND", "No calendar matched 'Privat'.")
+
+    def fake_run_jxa(script: str, *args: str, timeout: int | None = None) -> dict[str, object]:
+        return {
+            "event_id": "new-uid-1",
+            "title": args[1],
+            "calendar_id": args[0],
+            "calendar_name": args[0],
+            "start": "2028-06-01T09:00:00+00:00",
+            "end": "2028-06-01T09:30:00+00:00",
+            "all_day": False,
+            "location": None,
+            "notes": None,
+        }
+
+    monkeypatch.setattr(bridge, "_run_helper", fake_run_helper)
+    monkeypatch.setattr(bridge, "_run_jxa", fake_run_jxa)
+
+    event = bridge.create_event(
+        title="Telekom pruefen",
+        calendar_id="Privat",
+        start_iso="2028-06-01T09:00:00Z",
+        end_iso="2028-06-01T09:30:00Z",
+    )
+
+    assert event.event_id == "new-uid-1"
+    assert event.calendar_id == "Privat"
+
+
+def test_delete_event_falls_back_on_event_not_found(monkeypatch) -> None:
+    bridge = CalendarBridge(Path("/tmp/source.swift"), Path("/tmp/helper"))
+
+    def fake_run_helper(command: str, *args: str) -> dict[str, object]:
+        raise CalendarBridgeError("EVENT_NOT_FOUND", "missing")
+
+    def fake_run_jxa(script: str, *args: str, timeout: int | None = None) -> dict[str, object]:
+        return {"deleted": True}
+
+    monkeypatch.setattr(bridge, "_run_helper", fake_run_helper)
+    monkeypatch.setattr(bridge, "_run_jxa", fake_run_jxa)
+
+    assert bridge.delete_event("applescript-uid-1") is True
 
 
 def test_calendar_access_status_reads_helper_payload(monkeypatch) -> None:

--- a/AppleReminders-MCP/src/apple_reminders_mcp/apple_pim_bridge.swift
+++ b/AppleReminders-MCP/src/apple_reminders_mcp/apple_pim_bridge.swift
@@ -446,7 +446,11 @@ struct ApplePIMBridge {
 
     static func deleteEvent(store: EKEventStore, eventID: String) throws -> BooleanMutationPayload {
         guard let event = store.event(withIdentifier: eventID) else {
-            return BooleanMutationPayload(deleted: false, object_id: eventID)
+            throw BridgeFailure(
+                errorCode: "EVENT_NOT_FOUND",
+                message: "No event matched '\(eventID)'.",
+                suggestion: "List calendar events first to discover valid ids."
+            )
         }
         try store.remove(event, span: .thisEvent, commit: true)
         return BooleanMutationPayload(deleted: true, object_id: eventID)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Refreshed compatible transitive dependencies in the workspace lockfile.
 
 ### Fixed
+- Calendar `create_event`, `get_event`, `update_event`, and `delete_event` now retry through the AppleScript fallback under write-only ("Add Only") Calendar access, matching the existing read-path fallback; the native bridge's `deleteEvent` now reports a missing event as `EVENT_NOT_FOUND` instead of a silent `deleted: false`. (#7)
 - Archive mailbox auto-detection now inspects Mail only instead of probing unrelated Calendar, Reminders, and Notes defaults.
 - Unified-server tests no longer call live Contacts or filesystem resource bridges when their test data is mocked.
 


### PR DESCRIPTION
## Problem

Under `EKAuthorizationStatus.writeOnly` (Calendar granted "Add Only"), `calendar_access_status()` reports `can_read_events: false` but `can_write_events: true`. `list_calendars`/`list_events` already degrade gracefully to the JXA/AppleScript fallback in that case, but that fallback can only ever hand out calendar **names** (`cal.name()`) and AppleScript event `uid`s, never real `EKCalendar`/`EKEvent` identifiers, since EventKit itself won't enumerate calendars/events under this permission tier.

`create_event`, `get_event`, `update_event` and `delete_event` had no such fallback. They always call straight into the native Swift helper, which does `store.calendar(withIdentifier:)` / `store.event(withIdentifier:)` — these can never resolve a plain calendar name or an AppleScript-flavoured id, so every call reliably fails with `CALENDAR_NOT_FOUND` / `EVENT_NOT_FOUND`, even though the ids came straight out of `list_calendars`/`list_events` moments earlier.

On top of that, `deleteEvent` in the Swift helper swallows a missed lookup into a soft `{"deleted": false}` instead of throwing `EVENT_NOT_FOUND` the way `getEvent`/`updateEvent` do, which would have silently defeated a Python-side fallback anyway.

## Fix

- Add an AppleScript/JXA fallback for `create_event`, `get_event`, `update_event` and `delete_event`, mirroring the existing read-path fallback: locate the target calendar by name and the event by `uid` (with a secondary match on the synthetic `applescript::calendar::start::title` id the events fallback can emit for calendars without a native uid).
- `update_event` fallback supports moving an event to a different calendar (delete + recreate, since AppleScript has no native move).
- `deleteEvent` (Swift) now throws `EVENT_NOT_FOUND` on a missed lookup instead of returning `deleted: false`, matching `getEvent`/`updateEvent` and letting the Python-side fallback trigger correctly.
- New `_should_use_fallback` extends the existing `_should_use_read_fallback` permission-error set with `CALENDAR_NOT_FOUND`/`EVENT_NOT_FOUND` for the write paths.

## Testing

Verified end-to-end against a real macOS Calendar (write-only access): create → get → update → delete all round-trip correctly through the new fallback, including a full cleanup pass confirming deleted events are actually gone. Existing test suite green (`test_get_event_raises_when_missing` updated to match the new, still-correct "genuinely missing event still raises EVENT_NOT_FOUND" behavior once the fallback also can't find it), plus 4 new tests covering the fallback paths. `ruff check` clean.

```
23 passed (was 19 passed + this PR's 4 new tests)
```