### PR TITLE
Bound Notes AppleScript calls and resolve ambiguous create timeouts

### DIFF
--- a/AppleNotes-MCP/README.md
+++ b/AppleNotes-MCP/README.md
@@ -92,6 +92,10 @@ claude mcp add --transport stdio --scope project apple-notes -- uvx apple-mcp-no
 
 `stdio` is the default and recommended transport. Set `APPLE_NOTES_MCP_TRANSPORT=streamable-http` (with optional `APPLE_NOTES_MCP_HOST` and `APPLE_NOTES_MCP_PORT`) to serve Streamable HTTP instead.
 
+## Script Timeout
+
+Every AppleScript call is bounded by `APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS` (default `60`, minimum `5`) so a stalled Notes.app can never hang an MCP request indefinitely. If a create-note call times out after the note was already committed, the server looks the note up by title in the target folder and returns it; when the outcome cannot be verified it returns a structured `NOTE_CREATE_STATUS_UNKNOWN` error instead of leaving the client guessing.
+
 ## macOS Permissions
 
 - Automation access to Notes is required

--- a/AppleNotes-MCP/src/apple_notes_mcp/applescripts/create_note.applescript
+++ b/AppleNotes-MCP/src/apple_notes_mcp/applescripts/create_note.applescript
@@ -62,17 +62,28 @@ on note_json(accountId, accountName, folderId, folderName, n)
 	set bodyHtml to ""
 	set plainText to ""
 	set attachmentCount to 0
+	-- The note already exists at this point; a stalled readback (Notes can
+	-- block on body/plaintext while syncing) must degrade to empty fields
+	-- instead of hanging the whole script past the caller's deadline.
 	try
-		set titleText to my safe_text(name of n)
+		with timeout of 10 seconds
+			set titleText to my safe_text(name of n)
+		end timeout
 	end try
 	try
-		set bodyHtml to my safe_text(body of n)
+		with timeout of 10 seconds
+			set bodyHtml to my safe_text(body of n)
+		end timeout
 	end try
 	try
-		set plainText to my safe_text(plaintext of n)
+		with timeout of 10 seconds
+			set plainText to my safe_text(plaintext of n)
+		end timeout
 	end try
 	try
-		set attachmentCount to count of attachments of n
+		with timeout of 10 seconds
+			set attachmentCount to count of attachments of n
+		end timeout
 	end try
 	return "{" & ¬
 		quote & "note_id" & quote & ":" & my json_string(noteId) & "," & ¬

--- a/AppleNotes-MCP/src/apple_notes_mcp/config.py
+++ b/AppleNotes-MCP/src/apple_notes_mcp/config.py
@@ -8,6 +8,10 @@ SafetyMode = Literal["safe_readonly", "safe_manage", "full_access"]
 VALID_SAFETY_MODES = frozenset({"safe_readonly", "safe_manage", "full_access"})
 
 
+DEFAULT_SCRIPT_TIMEOUT_SECONDS = 60
+MIN_SCRIPT_TIMEOUT_SECONDS = 5
+
+
 @dataclass(frozen=True)
 class Settings:
     server_name: str
@@ -17,12 +21,25 @@ class Settings:
     allowed_folders: tuple[str, ...]
     log_level: str
     scripts_dir: Path
+    script_timeout_seconds: int
 
 
 def _parse_csv(value: str | None) -> tuple[str, ...]:
     if value is None:
         return ()
     return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _parse_script_timeout(value: str | None) -> int:
+    if value is None:
+        return DEFAULT_SCRIPT_TIMEOUT_SECONDS
+    try:
+        parsed = int(value.strip())
+    except ValueError:
+        return DEFAULT_SCRIPT_TIMEOUT_SECONDS
+    if parsed < MIN_SCRIPT_TIMEOUT_SECONDS:
+        return DEFAULT_SCRIPT_TIMEOUT_SECONDS
+    return parsed
 
 
 @lru_cache(maxsize=1)
@@ -40,4 +57,5 @@ def load_settings() -> Settings:
         allowed_folders=_parse_csv(os.environ.get("APPLE_NOTES_MCP_ALLOWED_FOLDERS")),
         log_level=os.environ.get("APPLE_NOTES_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",
         scripts_dir=package_dir / "applescripts",
+        script_timeout_seconds=_parse_script_timeout(os.environ.get("APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS")),
     )

--- a/AppleNotes-MCP/src/apple_notes_mcp/notes_bridge.py
+++ b/AppleNotes-MCP/src/apple_notes_mcp/notes_bridge.py
@@ -21,8 +21,13 @@ class NotesBridgeError(Exception):
 
 
 class AppleNotesBridge:
-    def __init__(self, scripts_dir: Path) -> None:
+    # After a create-script timeout, a same-title note only counts as the one
+    # we just made when its creation date is at most this old (or unknown).
+    _CREATE_RECOVERY_FRESHNESS_SECONDS = 600
+
+    def __init__(self, scripts_dir: Path, script_timeout_seconds: int = 60) -> None:
         self.scripts_dir = scripts_dir
+        self.script_timeout_seconds = script_timeout_seconds
         self._body_html_cache: dict[str, str] = {}
 
     def list_accounts(self) -> list[AccountInfo]:
@@ -63,17 +68,32 @@ class AppleNotesBridge:
         tags: list[str] | None = None,
     ) -> NoteDetail:
         prepared_body_html = self._prepare_body_html(title, body_html) if body_html is not None else None
-        payload = self._run_script(
-            "create_note.applescript",
-            title,
-            folder_id,
-            "",
-            "",
-        )
-        raw_note = payload.get("note")
-        if not isinstance(raw_note, dict):
-            raise NotesBridgeError("INVALID_SCRIPT_OUTPUT", "The create_note AppleScript did not return a note object.", "Inspect the AppleScript output and try again.")
-        detail = self._normalize_detail(raw_note)
+        try:
+            payload = self._run_script(
+                "create_note.applescript",
+                title,
+                folder_id,
+                "",
+                "",
+            )
+        except NotesBridgeError as exc:
+            if exc.error_code != "APPLESCRIPT_TIMEOUT":
+                raise
+            # Notes can commit `make new note` and then stall in the readback,
+            # so a timeout leaves the create ambiguous. Creation is not
+            # idempotent: resolve the outcome instead of making callers guess.
+            detail = self._recover_created_note(title, folder_id)
+            if detail is None:
+                raise NotesBridgeError(
+                    "NOTE_CREATE_STATUS_UNKNOWN",
+                    f"The create-note AppleScript timed out after {self.script_timeout_seconds} seconds and the outcome could not be verified: a note titled '{title}' may or may not exist in folder '{folder_id}'.",
+                    "Do not retry blindly. List notes in the target folder and check for the title before creating again.",
+                ) from exc
+        else:
+            raw_note = payload.get("note")
+            if not isinstance(raw_note, dict):
+                raise NotesBridgeError("INVALID_SCRIPT_OUTPUT", "The create_note AppleScript did not return a note object.", "Inspect the AppleScript output and try again.")
+            detail = self._normalize_detail(raw_note)
         if body_html or tags:
             last_error: NotesBridgeError | None = None
             for _ in range(3):
@@ -86,7 +106,11 @@ class AppleNotesBridge:
                 except NotesBridgeError as exc:
                     last_error = exc
             if last_error is not None:
-                raise last_error
+                raise NotesBridgeError(
+                    last_error.error_code,
+                    f"The note was created (note_id '{detail.note_id}') but applying its body/tags failed: {last_error.message}",
+                    f"Retry with an update on note_id '{detail.note_id}' instead of creating again; a repeated create would duplicate the note.",
+                ) from last_error
         if detail.body_html:
             self._body_html_cache[detail.note_id] = detail.body_html
         return detail
@@ -186,13 +210,44 @@ class AppleNotesBridge:
         matched.sort(key=lambda item: item.modified_epoch or 0, reverse=True)
         return matched[: max(1, min(limit, 100))]
 
+    def _recover_created_note(self, title: str, folder_id: str) -> NoteDetail | None:
+        # Only claim recovery when exactly one note in the target folder has
+        # the exact title and is fresh enough (or has no creation date) to be
+        # the one just created — a lone stale match is a pre-existing note.
+        try:
+            candidates = [note for note in self.list_notes(folder_id=folder_id) if note.title == title]
+        except NotesBridgeError:
+            return None
+        if len(candidates) != 1:
+            return None
+        candidate = candidates[0]
+        created_epoch = candidate.created_epoch or 0
+        if created_epoch and created_epoch < time.time() - self._CREATE_RECOVERY_FRESHNESS_SECONDS:
+            return None
+        try:
+            return self.get_note(candidate.note_id)
+        except NotesBridgeError:
+            return None
+
     def _run_script(self, script_name: str, *args: str) -> dict[str, object]:
         script_path = self.scripts_dir / script_name
         if not script_path.exists():
             raise NotesBridgeError("SCRIPT_NOT_FOUND", f"Missing AppleScript file '{script_name}'.", "Restore the AppleScript file and try again.")
 
         try:
-            completed = subprocess.run(["osascript", str(script_path), *args], capture_output=True, text=True, check=False)
+            completed = subprocess.run(
+                ["osascript", str(script_path), *args],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.script_timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise NotesBridgeError(
+                "APPLESCRIPT_TIMEOUT",
+                f"AppleScript '{script_name}' timed out after {self.script_timeout_seconds} seconds.",
+                "Notes.app may be busy or syncing; a mutation may already have been applied. Verify state before retrying non-idempotent operations.",
+            ) from exc
         except OSError as exc:
             raise NotesBridgeError("OSASCRIPT_UNAVAILABLE", f"Could not run 'osascript': {exc}.", "This server requires macOS with osascript available.") from exc
         if completed.returncode != 0:
@@ -337,4 +392,5 @@ class AppleNotesBridge:
 
 @lru_cache(maxsize=1)
 def build_bridge() -> AppleNotesBridge:
-    return AppleNotesBridge(load_settings().scripts_dir)
+    settings = load_settings()
+    return AppleNotesBridge(settings.scripts_dir, script_timeout_seconds=settings.script_timeout_seconds)

--- a/AppleNotes-MCP/tests/test_bridge.py
+++ b/AppleNotes-MCP/tests/test_bridge.py
@@ -1,11 +1,31 @@
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
 from apple_notes_mcp.notes_bridge import AppleNotesBridge, NotesBridgeError
+
+
+def _note_payload(note_id: str, title: str, created_epoch: int = 0) -> dict[str, object]:
+    return {
+        "note_id": note_id,
+        "title": title,
+        "account_id": "acc-1",
+        "account_name": "iCloud",
+        "folder_id": "folder-1",
+        "folder_name": "Personal",
+        "created_epoch": created_epoch,
+        "modified_epoch": created_epoch,
+        "password_protected": False,
+        "shared": False,
+        "attachment_count": 0,
+        "plaintext": "",
+        "body_html": "",
+        "attachments": [],
+    }
 
 
 def test_list_accounts_normalizes_payload(monkeypatch) -> None:
@@ -206,6 +226,119 @@ def test_create_note_uses_update_path_when_body_or_tags_present(monkeypatch) -> 
 
     assert detail.title == "Dallas trip"
     assert detail.body_html == "<div>Places to visit</div>"
+
+
+def test_run_script_times_out_with_structured_error(monkeypatch, tmp_path) -> None:
+    # Regression for issue #6: subprocess.run had no timeout, so a stalled
+    # osascript blocked the MCP response forever.
+    (tmp_path / "list_accounts.applescript").write_text("on run argv\nend run\n")
+    bridge = AppleNotesBridge(tmp_path, script_timeout_seconds=5)
+
+    def fake_run(*args, **kwargs):
+        assert kwargs["timeout"] == 5
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+
+    monkeypatch.setattr("apple_notes_mcp.notes_bridge.subprocess.run", fake_run)
+
+    try:
+        bridge._run_script("list_accounts.applescript")
+    except NotesBridgeError as exc:
+        assert exc.error_code == "APPLESCRIPT_TIMEOUT"
+    else:
+        raise AssertionError("Expected NotesBridgeError")
+
+
+def test_create_note_recovers_note_after_create_timeout(monkeypatch) -> None:
+    # Issue #6's ambiguous-commit case: Notes committed `make new note` but the
+    # script stalled afterwards. The deterministic post-timeout lookup must
+    # return the created note instead of surfacing an ambiguous failure.
+    bridge = AppleNotesBridge(Path("/tmp/scripts"))
+    bridge._folder_by_id = lambda folder_id: None  # type: ignore[method-assign]
+    monkeypatch.setattr(bridge, "list_attachments", lambda note_id: [])
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        if script_name == "create_note.applescript":
+            raise NotesBridgeError("APPLESCRIPT_TIMEOUT", "timed out")
+        if script_name == "list_notes.applescript":
+            return {"items": [_note_payload("note-9", "Disposable title", created_epoch=int(time.time()))]}
+        if script_name == "get_note.applescript":
+            return {"found": True, "note": _note_payload("note-9", "Disposable title", created_epoch=int(time.time()))}
+        raise AssertionError(f"Unexpected script: {script_name}")
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    detail = bridge.create_note(title="Disposable title", folder_id="folder-1")
+
+    assert detail.note_id == "note-9"
+
+
+def test_create_note_raises_status_unknown_when_recovery_finds_nothing(monkeypatch) -> None:
+    bridge = AppleNotesBridge(Path("/tmp/scripts"))
+    bridge._folder_by_id = lambda folder_id: None  # type: ignore[method-assign]
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        if script_name == "create_note.applescript":
+            raise NotesBridgeError("APPLESCRIPT_TIMEOUT", "timed out")
+        if script_name == "list_notes.applescript":
+            return {"items": []}
+        raise AssertionError(f"Unexpected script: {script_name}")
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    try:
+        bridge.create_note(title="Disposable title", folder_id="folder-1")
+    except NotesBridgeError as exc:
+        assert exc.error_code == "NOTE_CREATE_STATUS_UNKNOWN"
+        assert "Do not retry blindly" in (exc.suggestion or "")
+    else:
+        raise AssertionError("Expected NotesBridgeError")
+
+
+def test_create_note_recovery_ignores_stale_same_title_note(monkeypatch) -> None:
+    # A lone match created long ago is a pre-existing note, not the one this
+    # call tried to create — recovery must not claim it as a fresh create.
+    bridge = AppleNotesBridge(Path("/tmp/scripts"))
+    bridge._folder_by_id = lambda folder_id: None  # type: ignore[method-assign]
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        if script_name == "create_note.applescript":
+            raise NotesBridgeError("APPLESCRIPT_TIMEOUT", "timed out")
+        if script_name == "list_notes.applescript":
+            return {"items": [_note_payload("note-old", "Disposable title", created_epoch=int(time.time()) - 86_400)]}
+        raise AssertionError(f"Unexpected script: {script_name}")
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    try:
+        bridge.create_note(title="Disposable title", folder_id="folder-1")
+    except NotesBridgeError as exc:
+        assert exc.error_code == "NOTE_CREATE_STATUS_UNKNOWN"
+    else:
+        raise AssertionError("Expected NotesBridgeError")
+
+
+def test_create_note_reports_note_id_when_post_create_update_fails(monkeypatch) -> None:
+    bridge = AppleNotesBridge(Path("/tmp/scripts"))
+    bridge._folder_by_id = lambda folder_id: None  # type: ignore[method-assign]
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        assert script_name == "create_note.applescript"
+        return {"note": _note_payload("note-1", "Dallas trip")}
+
+    def fake_update_note(note_id: str, **kwargs):
+        raise NotesBridgeError("APPLESCRIPT_TIMEOUT", "timed out")
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+    monkeypatch.setattr(bridge, "update_note", fake_update_note)
+    monkeypatch.setattr("apple_notes_mcp.notes_bridge.time.sleep", lambda _seconds: None)
+
+    try:
+        bridge.create_note(title="Dallas trip", folder_id="folder-1", body_html="<div>Places to visit</div>")
+    except NotesBridgeError as exc:
+        assert "note-1" in exc.message
+        assert "note-1" in (exc.suggestion or "")
+    else:
+        raise AssertionError("Expected NotesBridgeError")
 
 
 def test_normalize_detail_uses_override_when_notes_readback_is_empty() -> None:

--- a/AppleNotes-MCP/tests/test_config.py
+++ b/AppleNotes-MCP/tests/test_config.py
@@ -1,4 +1,4 @@
-from apple_notes_mcp.config import load_settings
+from apple_notes_mcp.config import DEFAULT_SCRIPT_TIMEOUT_SECONDS, load_settings
 
 
 def test_load_settings_uses_packaged_applescripts() -> None:
@@ -12,3 +12,24 @@ def test_load_settings_uses_packaged_applescripts() -> None:
     assert settings.scripts_dir.name == "applescripts"
     assert settings.scripts_dir.parent.name == "apple_notes_mcp"
     assert settings.scripts_dir.exists()
+    assert settings.script_timeout_seconds == DEFAULT_SCRIPT_TIMEOUT_SECONDS
+
+
+def test_load_settings_reads_script_timeout_from_env(monkeypatch) -> None:
+    load_settings.cache_clear()
+    monkeypatch.setenv("APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS", "120")
+
+    try:
+        assert load_settings().script_timeout_seconds == 120
+    finally:
+        load_settings.cache_clear()
+
+
+def test_load_settings_rejects_invalid_script_timeout(monkeypatch) -> None:
+    load_settings.cache_clear()
+    monkeypatch.setenv("APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS", "0")
+
+    try:
+        assert load_settings().script_timeout_seconds == DEFAULT_SCRIPT_TIMEOUT_SECONDS
+    finally:
+        load_settings.cache_clear()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 - Calendar `create_event`, `get_event`, `update_event`, and `delete_event` now retry through the AppleScript fallback under write-only ("Add Only") Calendar access, matching the existing read-path fallback; the native bridge's `deleteEvent` now reports a missing event as `EVENT_NOT_FOUND` instead of a silent `deleted: false`. (#7)
+- Notes AppleScript calls are now bounded by a configurable timeout (`APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS`, default 60s) instead of hanging indefinitely, and `notes_create_note` resolves the ambiguous case where Notes commits the note but stalls afterwards: the created note is recovered by a deterministic folder/title lookup, or a structured `NOTE_CREATE_STATUS_UNKNOWN` error warns the client not to retry blindly. Post-create readbacks inside the AppleScript are also capped so the note id still comes back when Notes stalls on body/plaintext. (#6)
 - Archive mailbox auto-detection now inspects Mail only instead of probing unrelated Calendar, Reminders, and Notes defaults.
 - Unified-server tests no longer call live Contacts or filesystem resource bridges when their test data is mocked.
 


### PR DESCRIPTION
Fixes #6.

## Problem

`notes_create_note` could create the note in Apple Notes and then never return: `AppleNotesBridge._run_script()` invoked `subprocess.run()` with no timeout, and Notes can commit `make new note` and then stall in the post-create readback (`body`/`plaintext` while syncing). The client times out against a committed, non-idempotent side effect — exactly the ambiguous-commit hazard described in the issue.

## Fix

Three layers, mirroring the timeout pattern already used by the Calendar bridge:

1. **Hard backstop** — every AppleScript call is bounded by `APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS` (default 60s, min 5s); `subprocess.TimeoutExpired` maps to a structured `APPLESCRIPT_TIMEOUT` error and the osascript child is killed.
2. **In-script cap** — `create_note.applescript` wraps each post-create readback in `with timeout of 10 seconds`, so the common stall degrades to empty fields while still returning the note id (best outcome: success with id).
3. **Ambiguous-commit recovery** — if the create script still times out, `create_note` looks the note up by exact title in the target folder (single fresh match required; a lone stale match is treated as pre-existing). Found → returned as success. Not found → structured `NOTE_CREATE_STATUS_UNKNOWN` error explicitly warning the caller not to retry blindly.

Additionally, when the post-create body/tags update fails after retries, the error now carries the created note id so callers can recover with an update instead of a duplicating re-create.

## Testing

- 26/26 AppleNotes-MCP tests pass (8 new: timeout mapping, recovery success, zero-match and stale-match ambiguity, note-id-in-error, config parsing), `osacompile` validates the AppleScript change, 49/49 Apple-Tools tests pass, `ruff check` clean.
- Live smoke test: a real stalled osascript raises `APPLESCRIPT_TIMEOUT` at exactly the configured deadline with no leftover osascript process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)