### PR TITLE
Harden repo maintenance: CI enforcement, Dependabot, release tooling, docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Weekly, grouped dependency updates. Each ecosystem opens at most one PR per
+# week; review and merge like any other PR — CI gates them the same way.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,15 @@
 name: CI
 
+# No paths-ignore filters: branch protection requires these checks, and a PR
+# that never triggers the workflow would wait on them forever. Docs-only runs
+# are cheap; skipped required checks are a stuck merge button.
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
 permissions:
   contents: read
@@ -22,6 +19,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  bridge-sync:
+    # The EventKit Swift bridge is vendored into Apple-Calendar-MCP and
+    # AppleReminders-MCP; the copies must stay byte-identical.
+    name: Bridge sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Check vendored bridge copies match
+        run: bash scripts/check_bridge_sync.sh
+
+  swift-typecheck:
+    # The Swift helpers are compiled on user machines at first run, so a
+    # type error would only surface after install. Catch it here instead.
+    name: Swift typecheck
+    runs-on: macos-15
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Typecheck vendored Swift sources
+        # -parse-as-library matches how the bridges compile these helpers at
+        # runtime (they use @main, which single-file script mode rejects).
+        run: |
+          set -euo pipefail
+          find . -name '*.swift' -not -path './.venv/*' -print0 | while IFS= read -r -d '' src; do
+            echo "::group::${src}"
+            swiftc -parse-as-library -typecheck "$src"
+            echo "::endgroup::"
+          done
+
   lint:
     name: Ruff
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+- CI now enforces the vendored Swift bridge sync (`scripts/check_bridge_sync.sh`) and type-checks every Swift source with `swiftc -typecheck` on macOS.
+- Dependabot keeps the uv lockfile and GitHub Actions current with weekly grouped update PRs.
+- `scripts/bump_version.py` bumps the suite version across every package's `pyproject.toml`, `config.py`, `manifest.json`, and `server.json` in one step.
+- `docs/troubleshooting.md` covers macOS Automation prompts, Calendar "Add Only" access, Notes timeouts, and common error codes.
+
 ### Changed
+- CI runs on every pull request, including docs-only changes, so required status checks can never leave a merge waiting on a skipped workflow.
 - Refreshed compatible transitive dependencies in the workspace lockfile.
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ cd /path/to/Apple-MCPs/<server>
 uv run --project . python -m pytest
 ```
 
-The Swift bridge sources are vendored per package (`Apple-Calendar-MCP` and `AppleReminders-MCP` share `apple_pim_bridge.swift`); if you change one copy, run `bash scripts/check_bridge_sync.sh` to confirm the copies still match.
+The Swift bridge sources are vendored per package (`Apple-Calendar-MCP` and `AppleReminders-MCP` share `apple_pim_bridge.swift`); if you change one copy, run `bash scripts/check_bridge_sync.sh` to confirm the copies still match (CI enforces this).
 
 ## Required Checks
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The repository is a uv workspace: `pyproject.toml` at the root defines members, 
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [SECURITY.md](./SECURITY.md)
 - [Code Mode](./docs/code-mode.md)
+- [Troubleshooting](./docs/troubleshooting.md) — macOS permissions, timeouts, common error codes
 - [Publishing](./docs/publishing.md)
 - [NOTICE.md](./NOTICE.md) — trademark notice
 - [Launch docs](./docs/launch/) — golden workflows, failure modes, compatibility, demo script

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -21,6 +21,19 @@ PyPI description (the README). Do not remove these markers, and make sure the
 README is included in the sdist/wheel metadata (it is, via `readme = "README.md"`
 in each `pyproject.toml`).
 
+## 0. Bump versions
+
+The suite version lives in ~4 files per package. Bump every copy in one step,
+then update `CHANGELOG.md` (move `[Unreleased]` entries under the new
+heading), refresh the lockfile, and run the test suites:
+
+```bash
+python3 scripts/bump_version.py 1.0.3
+uv sync --all-packages
+```
+
+Tagging `vX.Y.Z` after committing triggers the release workflow.
+
 ## 1. Publish packages to PyPI with uv
 
 Order matters: every server depends on `apple-mcp-common>=1.0.0,<2`, so publish

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,77 @@
+# Troubleshooting
+
+Answers for the questions macOS permissions generate. If an issue is not
+covered here, please open a bug report — the template asks for the health
+tool output, which is the fastest way to diagnose anything below.
+
+## Start with the health tools
+
+Every server exposes diagnostic tools; call them before anything else:
+
+- `<server>_health` (for example `notes_health`, `calendar_health`) reports
+  version, safety mode, and capability state.
+- `<server>_permission_guide` explains exactly which macOS permission is
+  missing and how to grant it.
+- `<server>_recheck_permissions` re-probes after you change a setting, so you
+  don't need to restart the client.
+
+## Automation permission prompts (all servers)
+
+The AppleScript-backed servers (Notes, Mail, Messages, and the Calendar
+fallback) need **Automation** consent, and macOS grants it to the *host
+application* that runs the server — Terminal, Claude Desktop, your IDE — not
+to the server itself.
+
+- The prompt appears once, on first use. If it was dismissed or denied:
+  System Settings → Privacy & Security → **Automation** → find the host app →
+  enable the target app (Notes, Calendar, ...).
+- Running the same server from a different host app triggers a fresh prompt —
+  that is expected.
+- To force the prompt to reappear: `tccutil reset AppleEvents` (resets
+  Automation consent for all apps, so other tools will re-prompt too).
+
+## Calendar: "Add Only" access behaves differently
+
+macOS offers two grant levels for Calendar (System Settings → Privacy &
+Security → **Calendars**): Full Access and **Add Only**. Under Add Only the
+native EventKit helper cannot read calendars or events, so the server
+transparently falls back to AppleScript:
+
+- Everything works (list, get, create, update, delete), but calendar ids are
+  calendar **names** and event ids are AppleScript uids rather than EventKit
+  identifiers. Treat ids as opaque and short-lived: list first, then act.
+- `calendar_access_status` shows the current tier (`can_read_events` /
+  `can_write_events`). For full-fidelity ids and faster operations, grant
+  Full Access.
+
+## Notes: timeouts and the create-note guarantee
+
+Notes.app can stall mid-request while syncing (especially iCloud accounts).
+Every AppleScript call the Notes server makes is bounded by
+`APPLE_NOTES_MCP_SCRIPT_TIMEOUT_SECONDS` (default `60`, minimum `5`), so a
+stalled request returns a structured error instead of hanging your client.
+
+For `notes_create_note` specifically — creation is not idempotent, so the
+server never leaves you guessing:
+
+- If Notes committed the note but stalled afterwards, the server recovers it
+  by title lookup and returns success with the note id.
+- If the outcome genuinely cannot be verified, you get
+  `NOTE_CREATE_STATUS_UNKNOWN`. **Do not retry blindly** — list notes in the
+  target folder and check for the title first, otherwise you may create a
+  duplicate.
+
+## Common error codes
+
+| Code | Meaning | What to do |
+| --- | --- | --- |
+| `PERMISSION_DENIED` | macOS blocked automation or data access | Call `<server>_permission_guide`, grant the permission, then `<server>_recheck_permissions` |
+| `APPLESCRIPT_TIMEOUT` | The target app stalled past the deadline | The app may be busy or syncing; verify state before retrying a mutation |
+| `NOTE_CREATE_STATUS_UNKNOWN` | Create timed out and could not be verified | Check the target folder for the title before creating again |
+| `CALENDAR_NOT_FOUND` / `EVENT_NOT_FOUND` | Id did not resolve | List calendars/events first — ids change shape under Add Only access |
+
+## Still stuck?
+
+Open an issue with the health tool output and the exact error payload. Please
+do not include note bodies, event details, or other personal content —
+error codes and tool names are enough to diagnose almost everything.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Bump the suite version across every package in one step.
+
+The version string lives in four places per package (pyproject.toml,
+src/*/config.py, manifest.json, server.json), so a release touches ~40 files.
+This script rewrites every exact occurrence of the current version, reading
+the current version from AppleMCPCommon/pyproject.toml as the canonical
+source, and fails loudly if any expected file has drifted.
+
+Usage:
+    python3 scripts/bump_version.py 1.0.3 [--dry-run]
+
+Afterwards: add the release heading to CHANGELOG.md, run
+`uv sync --all-packages` to refresh the lockfile, run the test suites, commit,
+and tag `vX.Y.Z` to trigger the release workflow (see docs/publishing.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+PACKAGE_DIRS = (
+    "AppleMCPCommon",
+    "Apple-Tools-MCP",
+    "Apple-Calendar-MCP",
+    "AppleContacts-MCP",
+    "AppleFiles-MCP",
+    "AppleMail-MCP",
+    "AppleMaps-MCP",
+    "AppleMessages-MCP",
+    "AppleNotes-MCP",
+    "AppleReminders-MCP",
+    "AppleShortcuts-MCP",
+    "AppleSystem-MCP",
+)
+
+
+def read_current_version() -> str:
+    canonical = ROOT / "AppleMCPCommon" / "pyproject.toml"
+    match = re.search(r'^version = "([0-9]+\.[0-9]+\.[0-9]+)"$', canonical.read_text(), re.MULTILINE)
+    if match is None:
+        sys.exit(f"Could not find a version line in {canonical}")
+    return match.group(1)
+
+
+def candidate_files(package_dir: Path) -> list[Path]:
+    files = [package_dir / "pyproject.toml"]
+    files.extend(sorted(package_dir.glob("src/*/config.py")))
+    for name in ("manifest.json", "server.json"):
+        path = package_dir / name
+        if path.exists():
+            files.append(path)
+    return files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("new_version", help="new semantic version, e.g. 1.0.3")
+    parser.add_argument("--dry-run", action="store_true", help="report what would change without writing")
+    args = parser.parse_args()
+
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.new_version) is None:
+        sys.exit(f"'{args.new_version}' is not a plain X.Y.Z version")
+
+    current = read_current_version()
+    if current == args.new_version:
+        sys.exit(f"Packages are already at {current}")
+
+    # Exact patterns only: dependency ranges, spec dates, and manifest schema
+    # versions never match the quoted current version, so nothing else moves.
+    patterns = (
+        f'version = "{current}"',
+        f'version="{current}"',
+        f'"version": "{current}"',
+    )
+
+    total = 0
+    for dir_name in PACKAGE_DIRS:
+        package_dir = ROOT / dir_name
+        if not package_dir.is_dir():
+            sys.exit(f"Expected package directory missing: {package_dir}")
+        for path in candidate_files(package_dir):
+            if not path.exists():
+                sys.exit(f"Expected file missing: {path}")
+            text = path.read_text()
+            count = sum(text.count(pattern) for pattern in patterns)
+            if count == 0:
+                sys.exit(f"{path} contains no '{current}' version string; fix the drift before bumping")
+            for pattern in patterns:
+                text = text.replace(pattern, pattern.replace(current, args.new_version))
+            if not args.dry_run:
+                path.write_text(text)
+            total += count
+            print(f"{path.relative_to(ROOT)}: {count} occurrence(s)")
+
+    action = "Would update" if args.dry_run else "Updated"
+    print(f"\n{action} {total} version strings: {current} -> {args.new_version}")
+    if not args.dry_run:
+        print("Next: update CHANGELOG.md, run `uv sync --all-packages`, run tests, commit, then tag")
+        print(f"  git tag v{args.new_version} && git push origin v{args.new_version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Maintenance hardening so the repo enforces its own rules between sessions.

## CI
- **Bridge sync job**: runs `scripts/check_bridge_sync.sh` — the CONTRIBUTING rule that PR #7 slipped through is now machine-enforced.
- **Swift typecheck job**: `swiftc -parse-as-library -typecheck` on every vendored Swift source (same flags the bridges use to compile at runtime). The Swift layer previously had zero CI coverage; a type error would only surface on a user's machine at first run.
- **Removed `paths-ignore` filters**: branch protection with required checks + a workflow that skips docs-only PRs = a merge button stuck on "Expected — waiting for status" forever. Docs-only runs are cheap.

## Toil reduction
- **Dependabot**: weekly grouped PRs for the uv lockfile and GitHub Actions (no auto-merge; CI gates them like any PR).
- **`scripts/bump_version.py`**: the suite version lives in ~4 files × 12 packages (67 strings). One command now bumps them all, with drift detection and `--dry-run`. Verified: dry-run and real run both touch exactly 67 strings across 46 files. `docs/publishing.md` gains a step 0.
- **`docs/troubleshooting.md`**: the macOS-permission FAQ (Automation prompts, Calendar "Add Only" tier, Notes timeouts, error-code table) to link in issue replies, linked from the README.

## Verification
- Both workflows parse as valid YAML; `ruff check` clean; bridge-sync and the exact Swift typecheck loop run green locally on all three Swift sources.
- Follow-up after merge (settings, not code): branch protection on `main` requiring these checks — status checks only, no required reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)