### PR TITLE
Release v1.0.3

### DIFF
--- a/Apple-Calendar-MCP/manifest.json
+++ b/Apple-Calendar-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-calendar",
   "display_name": "Apple Calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "List, create, update, and delete events in Apple Calendar on macOS.",
   "long_description": "Local MCP server for Apple Calendar on macOS. Uses Apple's EventKit framework through a small native helper to list calendars, query events, create new events, update event details, and delete events while keeping Calendar as the system of record. Requires macOS and Apple Calendar installed.",
   "icon": "icon.png",

--- a/Apple-Calendar-MCP/pyproject.toml
+++ b/Apple-Calendar-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Calendar server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/Apple-Calendar-MCP/server.json
+++ b/Apple-Calendar-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "Apple-Calendar-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-calendar-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -46,7 +46,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-calendar-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "eeaff3e7c56c76860d38e17dc7a9a805d512a88ff1a01f35217f845e7f563710",
       "transport": {
         "type": "stdio"

--- a/Apple-Calendar-MCP/src/apple_calendar_mcp/config.py
+++ b/Apple-Calendar-MCP/src/apple_calendar_mcp/config.py
@@ -40,7 +40,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Calendar",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         allowed_calendars=_parse_allowed_calendars(os.environ.get("APPLE_CALENDAR_MCP_ALLOWED_CALENDARS")),
         log_level=os.environ.get("APPLE_CALENDAR_MCP_LOG_LEVEL", "INFO").strip() or "INFO",

--- a/Apple-Tools-MCP/manifest.json
+++ b/Apple-Tools-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-tools",
   "display_name": "Apple Tools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Unified Apple tools MCP server for macOS, covering Mail, Calendar, Reminders, Messages, Contacts, Notes, Shortcuts, Files, System, and Maps.",
   "long_description": "Local MCP server for Apple Mail, Calendar, Reminders, Messages, Contacts, Notes, Shortcuts, Files, System, and Maps on macOS. Reuses the standalone Apple-native integrations while providing one coherent agent entrypoint, unified health, cross-app prompts, aggregated overview resources, assistant workflows, Finder-aware file handling, and truthful system context.",
   "icon": "icon.png",

--- a/Apple-Tools-MCP/pyproject.toml
+++ b/Apple-Tools-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-tools-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Unified Apple ecosystem MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/Apple-Tools-MCP/server.json
+++ b/Apple-Tools-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "Apple-Tools-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-tools-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -142,7 +142,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-tools-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "39d703186a680278dc0900ede56da02643bdab969f3796cfe273a32021288c32",
       "transport": {
         "type": "stdio"

--- a/Apple-Tools-MCP/src/apple_agent_mcp/config.py
+++ b/Apple-Tools-MCP/src/apple_agent_mcp/config.py
@@ -27,7 +27,7 @@ def _parse_int(value: str | None, default: int) -> int:
 def load_settings() -> Settings:
     return Settings(
         server_name="Apple-Tools-MCP",
-        version="1.0.2",
+        version="1.0.3",
         transport=os.environ.get("APPLE_AGENT_MCP_TRANSPORT", "stdio").strip().lower() or "stdio",
         log_level=os.environ.get("APPLE_AGENT_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",
         host=os.environ.get("APPLE_AGENT_MCP_HOST", "127.0.0.1"),

--- a/AppleContacts-MCP/manifest.json
+++ b/AppleContacts-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-contacts",
   "display_name": "Apple Contacts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inspect and search Apple Contacts on macOS, and resolve a contact into a message-ready recipient.",
   "long_description": "Local MCP server for Apple Contacts on macOS. Uses AppleScript to inspect contacts, search by name, phone, or email, fetch full contact details, and resolve a contact into a message-ready recipient before handing off to Apple Messages.",
   "icon": "icon.png",

--- a/AppleContacts-MCP/pyproject.toml
+++ b/AppleContacts-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-contacts-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Contacts MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleContacts-MCP/server.json
+++ b/AppleContacts-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleContacts-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-contacts-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -39,7 +39,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-contacts-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "a7e3e5e75a413c5893f5f64fb7564dfce22c4162ca6bda26b429a9e3173ca0db",
       "transport": {
         "type": "stdio"

--- a/AppleContacts-MCP/src/apple_contacts_mcp/config.py
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/config.py
@@ -26,7 +26,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Contacts",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         log_level=os.environ.get("APPLE_CONTACTS_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",
         scripts_dir=package_dir / "applescripts",

--- a/AppleFiles-MCP/manifest.json
+++ b/AppleFiles-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-files",
   "display_name": "Apple Files",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inspect and manage local files and folders inside allowed roots on macOS.",
   "long_description": "Local MCP server for scoped file, Finder-adjacent, and iCloud Drive workflows on macOS. Use it to inspect directories, search files, read text files, prepare attachments, reveal paths in Finder, manage Finder tags, and perform bounded file mutations inside explicit allowed roots.",
   "icon": "icon.png",

--- a/AppleFiles-MCP/pyproject.toml
+++ b/AppleFiles-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-files-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Files MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleFiles-MCP/server.json
+++ b/AppleFiles-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleFiles-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-files-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -46,7 +46,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-files-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "52f05687fdbeafd64f44d4ef8d3f6e16c30cbd28a7b6f810a61d4df9b4686176",
       "transport": {
         "type": "stdio"

--- a/AppleFiles-MCP/src/apple_files_mcp/config.py
+++ b/AppleFiles-MCP/src/apple_files_mcp/config.py
@@ -52,7 +52,7 @@ def _parse_roots(value: str | None) -> tuple[Path, ...]:
 def load_settings() -> Settings:
     return Settings(
         server_name="Apple Files MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=os.environ.get("APPLE_FILES_MCP_SAFETY_MODE", "safe_manage").strip().lower() or "safe_manage",
         allowed_roots=_parse_roots(os.environ.get("APPLE_FILES_MCP_ALLOWED_ROOTS")),
         transport=os.environ.get("APPLE_FILES_MCP_TRANSPORT", "stdio").strip().lower() or "stdio",

--- a/AppleMCPCommon/pyproject.toml
+++ b/AppleMCPCommon/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-mcp-common"
-version = "1.0.2"
+version = "1.0.3"
 description = "Shared discovery and generation helpers for the Apple MCP suite"
 readme = "README.md"
 license = "MIT"

--- a/AppleMail-MCP/manifest.json
+++ b/AppleMail-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-mail",
   "display_name": "Apple Mail",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Read, search, compose, and send emails via Apple Mail on macOS.",
   "long_description": "Local MCP server for Apple Mail on macOS. Uses AppleScript to list mailboxes, search and read messages, compose drafts, and send email \u2014 all with Apple Mail as the system of record. Requires macOS and Apple Mail installed.",
   "icon": "icon.png",

--- a/AppleMail-MCP/pyproject.toml
+++ b/AppleMail-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-mcp-mail"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local MCP server for Apple Mail on macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleMail-MCP/server.json
+++ b/AppleMail-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleMail-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-mcp-mail",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-mail-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "fa5b69357b99d3a26b266d19468db4da259fbd8a8ba0a2bacf75b4eb16e9ad0a",
       "transport": {
         "type": "stdio"

--- a/AppleMail-MCP/src/apple_mail_mcp/config.py
+++ b/AppleMail-MCP/src/apple_mail_mcp/config.py
@@ -62,7 +62,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Mail MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_profile=safety_profile,
         transport=_parse_transport(os.getenv("APPLE_MAIL_MCP_TRANSPORT")),
         host=os.getenv("APPLE_MAIL_MCP_HOST", "127.0.0.1"),

--- a/AppleMaps-MCP/manifest.json
+++ b/AppleMaps-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-maps",
   "display_name": "Apple Maps",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Search places, estimate routes, and build Apple Maps links on macOS.",
   "long_description": "Local MCP server for Apple Maps workflows on macOS. Uses a local Swift helper to search places, estimate travel time, build Apple Maps links, and open directions in the Apple Maps app.",
   "icon": "icon.png",

--- a/AppleMaps-MCP/pyproject.toml
+++ b/AppleMaps-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-maps-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Maps MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleMaps-MCP/server.json
+++ b/AppleMaps-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleMaps-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-maps-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -25,7 +25,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-maps-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "337809eb0970848261469553343f8c63f208553138b4cde12602b751e5e498ca",
       "transport": {
         "type": "stdio"

--- a/AppleMaps-MCP/src/apple_maps_mcp/config.py
+++ b/AppleMaps-MCP/src/apple_maps_mcp/config.py
@@ -36,7 +36,7 @@ def load_settings() -> Settings:
     ).expanduser()
     return Settings(
         server_name="Apple Maps MCP",
-        version="1.0.2",
+        version="1.0.3",
         helper_source=package_dir / "apple_maps_bridge.swift",
         helper_binary=build_dir / "apple-maps-bridge",
         transport=os.environ.get("APPLE_MAPS_MCP_TRANSPORT", "stdio").strip().lower() or "stdio",

--- a/AppleMessages-MCP/manifest.json
+++ b/AppleMessages-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-messages",
   "display_name": "Apple Messages",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Read Messages history on macOS and send or reply through Messages.app.",
   "long_description": "Local MCP server for Apple Messages on macOS. Uses the local Messages SQLite database for history, search, and attachment metadata when Full Disk Access is available, and uses Messages.app automation for send and reply actions.",
   "icon": "icon.png",

--- a/AppleMessages-MCP/pyproject.toml
+++ b/AppleMessages-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-messages-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Messages MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleMessages-MCP/server.json
+++ b/AppleMessages-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleMessages-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-messages-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -39,7 +39,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-messages-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "3fe1d6c58bba103e85b33877c00a71c6d458fb27c6e03bc775d76330ca1d962c",
       "transport": {
         "type": "stdio"

--- a/AppleMessages-MCP/src/apple_messages_mcp/config.py
+++ b/AppleMessages-MCP/src/apple_messages_mcp/config.py
@@ -26,7 +26,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Messages MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         db_path=Path(os.environ.get("APPLE_MESSAGES_MCP_DB_PATH", str(Path.home() / "Library" / "Messages" / "chat.db"))).expanduser(),
         log_level=os.environ.get("APPLE_MESSAGES_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",

--- a/AppleNotes-MCP/manifest.json
+++ b/AppleNotes-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-notes",
   "display_name": "Apple Notes",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inspect, search, create, edit, move, and organize notes in Apple Notes on macOS.",
   "long_description": "Local MCP server for Apple Notes on macOS. Uses AppleScript as the primary bridge to list accounts and folders, inspect notes, search note contents, create and update notes, move notes between folders, and organize notes while keeping Notes as the system of record.",
   "icon": "icon.png",

--- a/AppleNotes-MCP/pyproject.toml
+++ b/AppleNotes-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-mcp-notes"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Notes MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleNotes-MCP/server.json
+++ b/AppleNotes-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleNotes-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-mcp-notes",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -53,7 +53,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-notes-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "011d38167551864a66e24b05fa9a2dffc3f620ea0bbbd41612787b4c61811d1c",
       "transport": {
         "type": "stdio"

--- a/AppleNotes-MCP/src/apple_notes_mcp/config.py
+++ b/AppleNotes-MCP/src/apple_notes_mcp/config.py
@@ -51,7 +51,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Notes MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         allowed_accounts=_parse_csv(os.environ.get("APPLE_NOTES_MCP_ALLOWED_ACCOUNTS")),
         allowed_folders=_parse_csv(os.environ.get("APPLE_NOTES_MCP_ALLOWED_FOLDERS")),

--- a/AppleReminders-MCP/manifest.json
+++ b/AppleReminders-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-reminders",
   "display_name": "Apple Reminders",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "List, create, update, complete, and delete reminders in Apple Reminders on macOS.",
   "long_description": "Local MCP server for Apple Reminders on macOS. Uses Apple's EventKit framework through a small native helper to list reminder lists, read reminder state, create reminders, update details, complete tasks, and delete reminders while keeping Reminders as the system of record.",
   "icon": "icon.png",

--- a/AppleReminders-MCP/pyproject.toml
+++ b/AppleReminders-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-mcp-reminders"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Reminders MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleReminders-MCP/server.json
+++ b/AppleReminders-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleReminders-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-mcp-reminders",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -46,7 +46,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-reminders-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "b5d0169018d03c371b78f0025d9a64835b325b637d2e344d502d6ce3e9c2794a",
       "transport": {
         "type": "stdio"

--- a/AppleReminders-MCP/src/apple_reminders_mcp/config.py
+++ b/AppleReminders-MCP/src/apple_reminders_mcp/config.py
@@ -40,7 +40,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Reminders MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         allowed_lists=_parse_allowed_lists(os.environ.get("APPLE_REMINDERS_MCP_ALLOWED_LISTS")),
         log_level=os.environ.get("APPLE_REMINDERS_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",

--- a/AppleShortcuts-MCP/manifest.json
+++ b/AppleShortcuts-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-shortcuts",
   "display_name": "Apple Shortcuts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "List, inspect, and run Apple Shortcuts on macOS.",
   "long_description": "Local MCP server for Apple Shortcuts on macOS. Uses the official shortcuts CLI to list shortcuts, inspect shortcut metadata, browse folders, and run shortcuts with structured inputs and outputs. Designed for agentic use with concise resources, prompts, and typed results.",
   "icon": "icon.png",

--- a/AppleShortcuts-MCP/pyproject.toml
+++ b/AppleShortcuts-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-shortcuts-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple Shortcuts MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleShortcuts-MCP/server.json
+++ b/AppleShortcuts-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleShortcuts-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-shortcuts-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -39,7 +39,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-shortcuts-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "6c6ccebd86b29bada7203afbf722e427cb5dbb5d17b1277a7c440674f0ff48f5",
       "transport": {
         "type": "stdio"

--- a/AppleShortcuts-MCP/src/apple_shortcuts_mcp/config.py
+++ b/AppleShortcuts-MCP/src/apple_shortcuts_mcp/config.py
@@ -40,7 +40,7 @@ def load_settings() -> Settings:
 
     return Settings(
         server_name="Apple Shortcuts MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=cast(SafetyMode, raw_safety_mode),
         log_level=os.environ.get("APPLE_SHORTCUTS_MCP_LOG_LEVEL", "INFO").strip().upper() or "INFO",
         transport=os.environ.get("APPLE_SHORTCUTS_MCP_TRANSPORT", "stdio").strip() or "stdio",

--- a/AppleSystem-MCP/manifest.json
+++ b/AppleSystem-MCP/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "apple-system",
   "display_name": "Apple System",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Read and manage macOS system settings and perform scoped desktop actions.",
   "long_description": "Local MCP server for macOS system context and control. Use it to inspect battery state, application state, system settings, clipboard, and notifications, and to apply bounded settings writes or GUI fallback actions with scoped safety controls.",
   "icon": "icon.png",

--- a/AppleSystem-MCP/pyproject.toml
+++ b/AppleSystem-MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-system-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "Local Apple System MCP server for macOS"
 readme = "README.md"
 license = "MIT"

--- a/AppleSystem-MCP/server.json
+++ b/AppleSystem-MCP/server.json
@@ -9,14 +9,14 @@
     "id": "1194217206",
     "subfolder": "AppleSystem-MCP"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "websiteUrl": "https://github.com/JonathanRReed/Apple-MCPs",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "apple-system-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -39,7 +39,7 @@
     {
       "registryType": "mcpb",
       "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-system-1.0.2.mcpb",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "fileSha256": "efdbdfb42c5157b6112f87830a1aeaf76c75367aa894def396bd0a4e6d0b792f",
       "transport": {
         "type": "stdio"

--- a/AppleSystem-MCP/src/apple_system_mcp/config.py
+++ b/AppleSystem-MCP/src/apple_system_mcp/config.py
@@ -27,7 +27,7 @@ def _parse_int(value: str | None, default: int) -> int:
 def load_settings() -> Settings:
     return Settings(
         server_name="Apple System MCP",
-        version="1.0.2",
+        version="1.0.3",
         safety_mode=os.environ.get("APPLE_SYSTEM_MCP_SAFETY_MODE", "safe_manage").strip().lower() or "safe_manage",
         transport=os.environ.get("APPLE_SYSTEM_MCP_TRANSPORT", "stdio").strip().lower() or "stdio",
         host=os.environ.get("APPLE_SYSTEM_MCP_HOST", "127.0.0.1"),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this repository will be documented in this file.
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning.
 
-## [Unreleased]
+## [1.0.3] - 2026-09-01
 
 ### Added
 - CI now enforces the vendored Swift bridge sync (`scripts/check_bridge_sync.sh`) and type-checks every Swift source with `swiftc -typecheck` on macOS.
@@ -14,7 +14,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 - CI runs on every pull request, including docs-only changes, so required status checks can never leave a merge waiting on a skipped workflow.
-- Refreshed compatible transitive dependencies in the workspace lockfile.
+- Minimum dependency floors raised to `mcp>=2.1.1` and `pydantic>=2.13.5`; refreshed compatible transitive dependencies in the workspace lockfile.
 
 ### Fixed
 - Calendar `create_event`, `get_event`, `update_event`, and `delete_event` now retry through the AppleScript fallback under write-only ("Add Only") Calendar access, matching the existing read-path fallback; the native bridge's `deleteEvent` now reports a missing event as `EVENT_NOT_FOUND` instead of a silent `deleted: false`. (#7)

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "apple-calendar-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "Apple-Calendar-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -73,7 +73,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleContacts-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -99,7 +99,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-files-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleFiles-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -125,7 +125,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-maps-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleMaps-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -151,7 +151,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-mcp-common"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleMCPCommon" }
 dependencies = [
     { name = "mcp" },
@@ -175,7 +175,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-mcp-mail"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleMail-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -201,7 +201,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-mcp-notes"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleNotes-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -227,7 +227,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-mcp-reminders"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleReminders-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -253,7 +253,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-messages-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleMessages-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -279,7 +279,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-shortcuts-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleShortcuts-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -305,7 +305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-system-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "AppleSystem-MCP" }
 dependencies = [
     { name = "apple-mcp-common" },
@@ -331,7 +331,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "apple-tools-mcp"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "Apple-Tools-MCP" }
 dependencies = [
     { name = "apple-calendar-mcp" },
@@ -573,8 +573,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1139,8 +1139,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [


### PR DESCRIPTION
Version bump for the v1.0.3 release: all 67 version strings via `scripts/bump_version.py` (its first live run), changelog promotion, lockfile refresh.

Ships to users:
- **Notes**: bounded AppleScript timeouts + deterministic recovery for the create-note hang (#6)
- **Calendar**: full CRUD under write-only "Add Only" access (#7)
- Dependency floors: `mcp>=2.1.1`, `pydantic>=2.13.5`

Verified locally: 205/205 tests across all 12 packages, ruff clean, bridge sync clean.

After merge: tag `v1.0.3` triggers the release workflow (build → PyPI trusted publishing → GitHub Release), then the MCP Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)