### PR TITLE
Point server.json MCPB entries at the v1.0.3 release assets

### DIFF
--- a/Apple-Calendar-MCP/server.json
+++ b/Apple-Calendar-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-calendar-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-calendar-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "eeaff3e7c56c76860d38e17dc7a9a805d512a88ff1a01f35217f845e7f563710",
+      "fileSha256": "e1388cf0e843804b27ba49a3d211a626f928206bd04b25cbccc965983747ab8a",
       "transport": {
         "type": "stdio"
       }

--- a/Apple-Tools-MCP/server.json
+++ b/Apple-Tools-MCP/server.json
@@ -141,9 +141,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-tools-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-tools-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "39d703186a680278dc0900ede56da02643bdab969f3796cfe273a32021288c32",
+      "fileSha256": "a491f33f48c98188f416727dfaa3763b63186ded7132dbd6bbe4d511d0998e9f",
       "transport": {
         "type": "stdio"
       }

--- a/AppleContacts-MCP/server.json
+++ b/AppleContacts-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-contacts-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-contacts-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "a7e3e5e75a413c5893f5f64fb7564dfce22c4162ca6bda26b429a9e3173ca0db",
+      "fileSha256": "6ca799482cd4a3425bc2da97b773553cf0e9929ae6d2c059959d0651fa32d1a1",
       "transport": {
         "type": "stdio"
       }

--- a/AppleFiles-MCP/server.json
+++ b/AppleFiles-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-files-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-files-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "52f05687fdbeafd64f44d4ef8d3f6e16c30cbd28a7b6f810a61d4df9b4686176",
+      "fileSha256": "d161f4a48fb3ab324a44bcdd0fd4ec50acd27a8d48c622f5c4f2ba9fccf86ee0",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMail-MCP/server.json
+++ b/AppleMail-MCP/server.json
@@ -51,9 +51,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-mail-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-mail-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "fa5b69357b99d3a26b266d19468db4da259fbd8a8ba0a2bacf75b4eb16e9ad0a",
+      "fileSha256": "ce9f9f5b982ca4498b003492d9bde8b4992424f52ce807305dc97046076a6661",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMaps-MCP/server.json
+++ b/AppleMaps-MCP/server.json
@@ -24,9 +24,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-maps-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-maps-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "337809eb0970848261469553343f8c63f208553138b4cde12602b751e5e498ca",
+      "fileSha256": "39f547c64b01d8da63e3c0ed21965db268a12db1ace8b50e48528d1b35f29fe0",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMessages-MCP/server.json
+++ b/AppleMessages-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-messages-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-messages-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "3fe1d6c58bba103e85b33877c00a71c6d458fb27c6e03bc775d76330ca1d962c",
+      "fileSha256": "f51b447329c32216ff98f1f7eb5337bc51e84753fa3bd62c2c967c2f03d34254",
       "transport": {
         "type": "stdio"
       }

--- a/AppleNotes-MCP/server.json
+++ b/AppleNotes-MCP/server.json
@@ -52,9 +52,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-notes-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-notes-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "011d38167551864a66e24b05fa9a2dffc3f620ea0bbbd41612787b4c61811d1c",
+      "fileSha256": "c23718d70e4a4dd7fc93c3db4882f4d6af63b46d03659d86f922b1ff3d4e8819",
       "transport": {
         "type": "stdio"
       }

--- a/AppleReminders-MCP/server.json
+++ b/AppleReminders-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-reminders-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-reminders-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "b5d0169018d03c371b78f0025d9a64835b325b637d2e344d502d6ce3e9c2794a",
+      "fileSha256": "c36be03d9c87a3ceefb720c1b2fcc1fcd6e5b4136c1147750737d6ffe903a279",
       "transport": {
         "type": "stdio"
       }

--- a/AppleShortcuts-MCP/server.json
+++ b/AppleShortcuts-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-shortcuts-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-shortcuts-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "6c6ccebd86b29bada7203afbf722e427cb5dbb5d17b1277a7c440674f0ff48f5",
+      "fileSha256": "17863c03bb0ea9289d4b5a6649a52b75c89d0f29c3b0e57197cea307f56ab1bb",
       "transport": {
         "type": "stdio"
       }

--- a/AppleSystem-MCP/server.json
+++ b/AppleSystem-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.2/apple-system-1.0.2.mcpb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-system-1.0.3.mcpb",
       "version": "1.0.3",
-      "fileSha256": "efdbdfb42c5157b6112f87830a1aeaf76c75367aa894def396bd0a4e6d0b792f",
+      "fileSha256": "bafee0e275a98e596523ab878f153f6f50656ab68467d969f635f90f22bf929c",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Post-release step 4 from docs/publishing.md: all 11 `server.json` mcpb entries now reference the v1.0.3 release bundles with their SHA-256 hashes from the release's `SHA256SUMS` (spot-verified against a real downloaded asset). Precedes the MCP Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)