### PR TITLE
Enforce Mail attachment allowlist

### DIFF
--- a/AppleMail-MCP/src/apple_mail_mcp/tools.py
+++ b/AppleMail-MCP/src/apple_mail_mcp/tools.py
@@ -173,6 +173,8 @@ def _validate_attachments(attachments: list[str] | None, allowed_root: Path | No
 
     validated: list[str] = []
     for attachment in attachments:
+        if "\x1d" in attachment or "\x00" in attachment:
+            raise ValueError("Attachment paths must not contain control separators")
         try:
             resolved_attachment = Path(attachment).expanduser().resolve(strict=True)
             resolved_attachment.relative_to(resolved_root)
@@ -180,6 +182,8 @@ def _validate_attachments(attachments: list[str] | None, allowed_root: Path | No
             raise ValueError(f"Attachment is not a file beneath the allowed attachment root: {attachment}") from exc
         if not resolved_attachment.is_file():
             raise ValueError(f"Attachment is not a regular file: {attachment}")
+        if "\x1d" in str(resolved_attachment) or "\x00" in str(resolved_attachment):
+            raise ValueError("Attachment paths must not contain control separators")
         validated.append(str(resolved_attachment))
     return validated
 
@@ -480,6 +484,8 @@ def mail_compose_draft(
         )
     except SafetyPolicyError as exc:
         return error_response("SAFETY_POLICY_BLOCK", str(exc))
+    except ValueError as exc:
+        return error_response("INVALID_INPUT", str(exc))
     except MailBridgeError as exc:
         return error_response("DRAFT_CREATE_FAILED", str(exc))
 
@@ -511,6 +517,8 @@ def mail_send_message(
         )
     except SafetyPolicyError as exc:
         return error_response("SAFETY_POLICY_BLOCK", str(exc))
+    except ValueError as exc:
+        return error_response("INVALID_INPUT", str(exc))
     except MailBridgeError as exc:
         return error_response("SEND_FAILED", str(exc))
 

--- a/AppleMail-MCP/src/apple_mail_mcp/tools.py
+++ b/AppleMail-MCP/src/apple_mail_mcp/tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import Annotations, ToolAnnotations
@@ -157,6 +158,32 @@ def mail_get_message_tool(bridge: AppleMailBridge, message_id: str) -> MessageRe
     return bridge.get_message(message_id)
 
 
+def _validate_attachments(attachments: list[str] | None, allowed_root: Path | None) -> list[str] | None:
+    if not attachments:
+        return attachments
+    if allowed_root is None:
+        raise ValueError("Attachments are disabled; configure APPLE_MAIL_MCP_ALLOWED_ATTACHMENT_ROOT to enable them")
+
+    try:
+        resolved_root = allowed_root.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError("The configured attachment root does not exist or cannot be accessed") from exc
+    if not resolved_root.is_dir():
+        raise ValueError("The configured attachment root must be a directory")
+
+    validated: list[str] = []
+    for attachment in attachments:
+        try:
+            resolved_attachment = Path(attachment).expanduser().resolve(strict=True)
+            resolved_attachment.relative_to(resolved_root)
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"Attachment is not a file beneath the allowed attachment root: {attachment}") from exc
+        if not resolved_attachment.is_file():
+            raise ValueError(f"Attachment is not a regular file: {attachment}")
+        validated.append(str(resolved_attachment))
+    return validated
+
+
 def mail_compose_draft_tool(
     bridge: AppleMailBridge,
     settings: Settings,
@@ -169,6 +196,7 @@ def mail_compose_draft_tool(
     from_account: str | None = None,
 ) -> DraftRecord:
     ensure_tool_allowed(settings.safety_profile, "mail_compose_draft")
+    attachments = _validate_attachments(attachments, settings.allowed_attachment_root)
     draft = bridge.compose_draft(
         to=to,
         cc=cc,
@@ -195,6 +223,7 @@ def mail_send_message_tool(
     from_account: str | None = None,
 ) -> SendRecord:
     ensure_tool_allowed(settings.safety_profile, "mail_send_message")
+    attachments = _validate_attachments(attachments, settings.allowed_attachment_root)
     result = bridge.send_message(
         to=to,
         cc=cc,

--- a/AppleMail-MCP/tests/test_tools.py
+++ b/AppleMail-MCP/tests/test_tools.py
@@ -440,3 +440,43 @@ def test_create_server_registers_clean_tool_names() -> None:
         "search_tools",
         "get_tool_info",
     }
+
+
+@pytest.mark.parametrize("operation_name", ["mail_compose_draft", "mail_send_message"])
+def test_attachment_rejection_returns_structured_error(operation_name, tmp_path):
+    from apple_mail_mcp import tools
+
+    result = getattr(tools, operation_name)(
+        to=["test@example.com"], attachments=[str(tmp_path / "document.txt")],
+        bridge=FakeBridge(), settings=Settings(safety_profile=SafetyProfile.FULL_ACCESS),
+    )
+    assert result.ok is False
+    assert result.error_code == "INVALID_INPUT"
+
+
+@pytest.mark.parametrize("through_symlink", [False, True])
+@pytest.mark.parametrize("operation", [mail_compose_draft_tool, mail_send_message_tool])
+def test_attachment_separator_cannot_inject_another_path(operation, through_symlink, tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    crafted = allowed / "document\x1d" / "etc" / "passwd"
+    crafted.parent.mkdir(parents=True)
+    crafted.write_text("test fixture")
+    candidate = crafted
+    if through_symlink:
+        candidate = allowed / "innocent.txt"
+        candidate.symlink_to(crafted)
+
+    class NoSendBridge(FakeBridge):
+        def compose_draft(self, *args, **kwargs):
+            raise AssertionError("Rejected attachment reached Mail")
+
+        def send_message(self, *args, **kwargs):
+            raise AssertionError("Rejected attachment reached Mail")
+
+    with pytest.raises(ValueError, match="control separators"):
+        operation(
+            NoSendBridge(), Settings(safety_profile=SafetyProfile.FULL_ACCESS, allowed_attachment_root=allowed),
+            to=["test@example.com"], cc=None, bcc=None, subject="Test", body="Body",
+            attachments=[str(candidate)],
+        )

--- a/AppleMail-MCP/tests/test_tools.py
+++ b/AppleMail-MCP/tests/test_tools.py
@@ -1,4 +1,7 @@
 import asyncio
+from pathlib import Path
+
+import pytest
 
 from apple_mail_mcp.config import Settings
 from apple_mail_mcp.models import (
@@ -282,6 +285,84 @@ def test_send_message_from_account_defaults_to_none() -> None:
 
     assert result.sent is True
     assert result.from_account is None
+
+
+@pytest.mark.parametrize("operation", [mail_compose_draft_tool, mail_send_message_tool])
+def test_attachment_operations_reject_attachments_when_disabled(operation, tmp_path: Path) -> None:
+    attachment = tmp_path / "document.txt"
+    attachment.write_text("private")
+    settings = Settings(safety_profile=SafetyProfile.FULL_ACCESS)
+
+    with pytest.raises(ValueError, match="Attachments are disabled"):
+        operation(
+            FakeBridge(), settings, to=["test@example.com"], cc=None, bcc=None,
+            subject="Test", body="Body", attachments=[str(attachment)],
+        )
+
+
+@pytest.mark.parametrize("operation", [mail_compose_draft_tool, mail_send_message_tool])
+def test_attachment_operations_enforce_allowed_root(operation, tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    outside = tmp_path / "private.txt"
+    outside.write_text("private")
+    settings = Settings(
+        safety_profile=SafetyProfile.FULL_ACCESS,
+        allowed_attachment_root=allowed_root,
+    )
+
+    with pytest.raises(ValueError, match="beneath the allowed attachment root"):
+        operation(
+            FakeBridge(), settings, to=["test@example.com"], cc=None, bcc=None,
+            subject="Test", body="Body", attachments=[str(outside)],
+        )
+
+
+def test_attachment_validation_resolves_allowed_regular_file(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    attachment = allowed_root / "document.txt"
+    attachment.write_text("content")
+
+    class CapturingBridge(FakeBridge):
+        received_attachments: list[str] | None = None
+
+        def send_message(self, *args, attachments=None, **kwargs) -> SendRecord:
+            self.received_attachments = attachments
+            return super().send_message(*args, attachments=attachments, **kwargs)
+
+    bridge = CapturingBridge()
+    mail_send_message_tool(
+        bridge,
+        Settings(safety_profile=SafetyProfile.FULL_ACCESS, allowed_attachment_root=allowed_root),
+        to=["test@example.com"], cc=None, bcc=None, subject="Test", body="Body",
+        attachments=[str(allowed_root / "." / "document.txt")],
+    )
+
+    assert bridge.received_attachments == [str(attachment.resolve())]
+
+
+@pytest.mark.parametrize("invalid_name", ["directory", "outside-link"])
+def test_attachment_validation_rejects_non_files_and_escaping_symlinks(tmp_path: Path, invalid_name: str) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    invalid_attachment = allowed_root / invalid_name
+    if invalid_name == "directory":
+        invalid_attachment.mkdir()
+        expected_error = "not a regular file"
+    else:
+        outside = tmp_path / "private.txt"
+        outside.write_text("private")
+        invalid_attachment.symlink_to(outside)
+        expected_error = "beneath the allowed attachment root"
+
+    with pytest.raises(ValueError, match=expected_error):
+        mail_send_message_tool(
+            FakeBridge(),
+            Settings(safety_profile=SafetyProfile.FULL_ACCESS, allowed_attachment_root=allowed_root),
+            to=["test@example.com"], cc=None, bcc=None, subject="Test", body="Body",
+            attachments=[str(invalid_attachment)],
+        )
 
 
 def test_reply_forward_mark_move_and_delete_tools() -> None:


### PR DESCRIPTION
### Motivation

- The repository parsed `APPLE_MAIL_MCP_ALLOWED_ATTACHMENT_ROOT` into `Settings.allowed_attachment_root` but never enforced it, allowing caller-controlled attachment paths to be forwarded to Mail and potentially exfiltrated.
- The intention is to restrict attachments to a configured directory boundary and prevent sending arbitrary local files, including symlink-escaped or non-regular files.

### Description

- Added a centralized `_validate_attachments` helper that requires `allowed_attachment_root` to be set, resolves the configured root strictly, verifies it is a directory, resolves each attachment strictly (canonicalizing symlinks), ensures each attachment is contained under the resolved root via `relative_to`, and verifies each target is a regular file; it returns canonicalized absolute paths for the bridge.
- Integrated attachment validation into both `mail_compose_draft_tool` and `mail_send_message_tool` so attachments are checked before reaching the AppleScript bridge and sending path.
- Added unit tests covering: behavior when attachments are disabled, rejection of outside-root paths, acceptance and canonicalization of valid regular files, and rejection of directories and symlinks that escape the allowed root.

### Testing

- Ran the repository unit test suite with `python -m pytest -q`, all tests passed (`27 passed`).
- Ran the linter `ruff` on `src` and `tests`, and static checks passed.
- New tests exercise the attachment validation logic and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a68244c348327823f2767d6368e08)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce attachment allowlist for `mail_compose_draft` and `mail_send_message` tools
> - Adds `tools._validate_attachments` helper that validates attachment paths against a configured root directory. It rejects requests when no root is configured, requires the root to exist, rejects control-separator and NUL characters, resolves each path, requires it to stay beneath the root, and requires it to be a regular file.
> - Applies validation in both `mail_compose_draft_tool` and `mail_send_message_tool` before calling bridge operations, forwarding canonical resolved paths for accepted attachments.
> - API wrappers `mail_compose_draft` and `mail_send_message` now catch `ValueError` from validation and return the existing `INVALID_INPUT` error response.
> - Behavioral Change: compose-draft and send-message now reject all attachment paths that are outside the configured root, are directories, are symlinks escaping the root, or contain control separators. When no attachment root is configured, all attachments are rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9d5da7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->