### PR TITLE
Bound Contacts AppleScript subprocess resource usage

### DIFF
--- a/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/list_contacts.applescript
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/list_contacts.applescript
@@ -3,18 +3,18 @@ on run argv
 	set resultOffset to (item 2 of argv) as integer
 	set jsonItems to {}
 	tell application "Contacts"
-		set people to every person
-		set peopleCount to count of people
+		set contactPeople to every person
+		set peopleCount to count of contactPeople
 		set firstIndex to resultOffset + 1
 		set lastIndex to resultOffset + resultLimit
 		if lastIndex > peopleCount then set lastIndex to peopleCount
 		if firstIndex <= lastIndex then
 			repeat with personIndex from firstIndex to lastIndex
-				set end of jsonItems to my person_json(item personIndex of people, false)
+				set end of jsonItems to my person_json(item personIndex of contactPeople, false)
 			end repeat
 		end if
 	end tell
-	return "{" & quote & "items" & quote & ":[" & my join_list(jsonItems, ",") & "]}"
+	return "{" & quote & "items" & quote & ":[" & my join_list(jsonItems, ",") & "]," & quote & "total" & quote & ":" & peopleCount & "}"
 end run
 
 on person_json(p, includeNote)

--- a/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/list_contacts.applescript
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/list_contacts.applescript
@@ -1,9 +1,18 @@
 on run argv
+	set resultLimit to (item 1 of argv) as integer
+	set resultOffset to (item 2 of argv) as integer
 	set jsonItems to {}
 	tell application "Contacts"
-		repeat with p in every person
-			set end of jsonItems to my person_json(p, false)
-		end repeat
+		set people to every person
+		set peopleCount to count of people
+		set firstIndex to resultOffset + 1
+		set lastIndex to resultOffset + resultLimit
+		if lastIndex > peopleCount then set lastIndex to peopleCount
+		if firstIndex <= lastIndex then
+			repeat with personIndex from firstIndex to lastIndex
+				set end of jsonItems to my person_json(item personIndex of people, false)
+			end repeat
+		end if
 	end tell
 	return "{" & quote & "items" & quote & ":[" & my join_list(jsonItems, ",") & "]}"
 end run

--- a/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/search_contacts.applescript
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/applescripts/search_contacts.applescript
@@ -1,11 +1,16 @@
 on run argv
 	set queryText to item 1 of argv
+	set resultLimit to (item 2 of argv) as integer
 	set jsonItems to {}
 	tell application "Contacts"
 		set matches to (every person whose name contains queryText or organization contains queryText)
-		repeat with p in matches
-			set end of jsonItems to my person_json(p, false)
-		end repeat
+		set matchCount to count of matches
+		if matchCount > resultLimit then set matchCount to resultLimit
+		if matchCount > 0 then
+			repeat with matchIndex from 1 to matchCount
+				set end of jsonItems to my person_json(item matchIndex of matches, false)
+			end repeat
+		end if
 	end tell
 	return "{" & quote & "items" & quote & ":[" & my join_list(jsonItems, ",") & "]}"
 end run

--- a/AppleContacts-MCP/src/apple_contacts_mcp/contacts_bridge.py
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/contacts_bridge.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterator
 from contextlib import suppress
 from pathlib import Path
 
@@ -18,6 +19,7 @@ NO_CHANGE_SENTINEL = "__NOCHANGE__"
 SCRIPT_TIMEOUT_SECONDS = 30
 MAX_SCRIPT_OUTPUT_BYTES = 8 * 1024 * 1024
 MAX_CONTACTS_PER_REQUEST = 1000
+MAX_DIRECTORY_CONTACTS = 100_000
 
 
 class ContactsBridgeError(Exception):
@@ -72,7 +74,7 @@ class AppleContactsBridge:
         normalized_query = self._normalize_lookup_value(query)
         exact_matches: list[ContactSummary] = []
         partial_matches: list[ContactSummary] = []
-        for contact in self.list_contacts(limit=MAX_CONTACTS_PER_REQUEST):
+        for contact in self._iter_all_contacts():
             if self._is_exact_match(contact, query_text, normalized_query):
                 exact_matches.append(contact)
                 continue
@@ -179,7 +181,7 @@ class AppleContactsBridge:
         )
 
     def find_duplicates(self) -> list[DuplicateCandidateGroup]:
-        contacts = self.list_contacts()
+        contacts = list(self._iter_all_contacts())
         if len(contacts) < 2:
             return []
 
@@ -283,6 +285,56 @@ class AppleContactsBridge:
             "Use a different contact.",
         )
 
+    def _iter_all_contacts(self) -> Iterator[ContactSummary]:
+        offset = 0
+        expected_total: int | None = None
+        while expected_total is None or offset < expected_total:
+            payload = self._run_script(
+                "list_contacts.applescript",
+                str(MAX_CONTACTS_PER_REQUEST),
+                str(offset),
+            )
+            raw_total = payload.get("total")
+            if not isinstance(raw_total, int) or isinstance(raw_total, bool) or raw_total < 0:
+                raise ContactsBridgeError(
+                    "INVALID_SCRIPT_OUTPUT",
+                    "The list_contacts AppleScript did not return a valid directory total.",
+                    "Inspect the AppleScript output and try again.",
+                )
+            if raw_total > MAX_DIRECTORY_CONTACTS:
+                raise ContactsBridgeError(
+                    "CONTACT_DIRECTORY_TOO_LARGE",
+                    f"The contact directory contains {raw_total} contacts, above the {MAX_DIRECTORY_CONTACTS}-contact scan limit.",
+                    "Narrow the search by name or reduce the directory size before retrying.",
+                )
+            if expected_total is None:
+                expected_total = raw_total
+            elif raw_total != expected_total:
+                raise ContactsBridgeError(
+                    "CONTACT_DIRECTORY_CHANGED",
+                    "The contact directory changed while it was being scanned.",
+                    "Retry the request after Contacts finishes updating.",
+                )
+
+            raw_items = payload.get("items")
+            if not isinstance(raw_items, list):
+                raise ContactsBridgeError(
+                    "INVALID_SCRIPT_OUTPUT",
+                    "The list_contacts AppleScript did not return an items array.",
+                    "Inspect the AppleScript output and try again.",
+                )
+            items = [self._normalize_summary(item) for item in raw_items if isinstance(item, dict)]
+            remaining = expected_total - offset
+            expected_page_size = min(MAX_CONTACTS_PER_REQUEST, remaining)
+            if len(items) != expected_page_size:
+                raise ContactsBridgeError(
+                    "INCOMPLETE_CONTACT_DIRECTORY",
+                    f"The contact scan returned {len(items)} of {expected_page_size} expected contacts at offset {offset}.",
+                    "Retry the request after Contacts finishes updating.",
+                )
+            yield from items
+            offset += len(items)
+
     def _run_script(self, script_name: str, *args: str) -> dict[str, object]:
         script_path = self.scripts_dir / script_name
         if not script_path.exists():
@@ -361,11 +413,13 @@ class AppleContactsBridge:
         return payload
 
     def _stop_process(self, process: subprocess.Popen[bytes]) -> None:
-        process.terminate()
+        with suppress(ProcessLookupError):
+            process.terminate()
         try:
             process.wait(timeout=1)
         except subprocess.TimeoutExpired:
-            process.kill()
+            with suppress(ProcessLookupError):
+                process.kill()
             process.wait()
 
     def _search_contacts_by_name(self, query: str, limit: int) -> list[ContactSummary]:

--- a/AppleContacts-MCP/src/apple_contacts_mcp/contacts_bridge.py
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/contacts_bridge.py
@@ -4,6 +4,9 @@ import hashlib
 import json
 import re
 import subprocess
+import tempfile
+import time
+from contextlib import suppress
 from pathlib import Path
 
 from apple_contacts_mcp.config import load_settings
@@ -12,6 +15,9 @@ from apple_contacts_mcp.models import ContactDetail, ContactMethod, ContactSumma
 METHOD_FIELD_SEPARATOR = "\x1f"
 METHOD_RECORD_SEPARATOR = "\x1e"
 NO_CHANGE_SENTINEL = "__NOCHANGE__"
+SCRIPT_TIMEOUT_SECONDS = 30
+MAX_SCRIPT_OUTPUT_BYTES = 8 * 1024 * 1024
+MAX_CONTACTS_PER_REQUEST = 1000
 
 
 class ContactsBridgeError(Exception):
@@ -33,8 +39,9 @@ class AppleContactsBridge:
         except ContactsBridgeError as exc:
             return False, exc
 
-    def list_contacts(self) -> list[ContactSummary]:
-        payload = self._run_script("list_contacts.applescript")
+    def list_contacts(self, limit: int = MAX_CONTACTS_PER_REQUEST, offset: int = 0) -> list[ContactSummary]:
+        bounded_limit = max(1, min(limit, MAX_CONTACTS_PER_REQUEST))
+        payload = self._run_script("list_contacts.applescript", str(bounded_limit), str(max(0, offset)))
         return [self._normalize_summary(item) for item in payload.get("items", []) if isinstance(item, dict)]
 
     def get_contact(self, contact_id: str) -> ContactDetail:
@@ -58,20 +65,21 @@ class AppleContactsBridge:
         query_text = query.strip().lower()
         if not query_text:
             raise ContactsBridgeError("INVALID_INPUT", "query must not be empty", "Provide a non-empty name, phone number, or email address.")
-        direct_matches = self._search_contacts_by_name(query)
+        bounded_limit = max(1, min(limit, 100))
+        direct_matches = self._search_contacts_by_name(query, bounded_limit)
         if direct_matches:
-            return direct_matches[: max(1, min(limit, 100))]
+            return direct_matches
         normalized_query = self._normalize_lookup_value(query)
         exact_matches: list[ContactSummary] = []
         partial_matches: list[ContactSummary] = []
-        for contact in self.list_contacts():
+        for contact in self.list_contacts(limit=MAX_CONTACTS_PER_REQUEST):
             if self._is_exact_match(contact, query_text, normalized_query):
                 exact_matches.append(contact)
                 continue
             if self._is_partial_match(contact, query_text, normalized_query):
                 partial_matches.append(contact)
         ordered = self._dedupe_contacts([*exact_matches, *partial_matches])
-        return ordered[: max(1, min(limit, 100))]
+        return ordered[:bounded_limit]
 
     def resolve_message_recipient(self, query: str, channel: str = "phone") -> ResolvedRecipientResponse:
         if channel not in {"phone", "email", "any"}:
@@ -285,17 +293,55 @@ class AppleContactsBridge:
             )
 
         try:
-            completed = subprocess.run(["osascript", str(script_path), *args], capture_output=True, text=True, check=False)
+            with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+                process = subprocess.Popen(
+                    ["osascript", str(script_path), *args],
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                )
+                deadline = time.monotonic() + SCRIPT_TIMEOUT_SECONDS
+                while process.poll() is None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        self._stop_process(process)
+                        raise ContactsBridgeError(
+                            "APPLESCRIPT_TIMEOUT",
+                            f"AppleScript exceeded the {SCRIPT_TIMEOUT_SECONDS}-second timeout.",
+                            "Ensure Contacts.app is responsive and try again.",
+                        )
+                    if stdout_file.tell() > MAX_SCRIPT_OUTPUT_BYTES or stderr_file.tell() > MAX_SCRIPT_OUTPUT_BYTES:
+                        self._stop_process(process)
+                        raise ContactsBridgeError(
+                            "APPLESCRIPT_OUTPUT_TOO_LARGE",
+                            "AppleScript output exceeded the allowed size.",
+                            "Request fewer contacts and try again.",
+                        )
+                    with suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=min(0.05, remaining))
+
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                stdout = stdout_file.read(MAX_SCRIPT_OUTPUT_BYTES + 1)
+                stderr = stderr_file.read(MAX_SCRIPT_OUTPUT_BYTES + 1)
+                if len(stdout) > MAX_SCRIPT_OUTPUT_BYTES or len(stderr) > MAX_SCRIPT_OUTPUT_BYTES:
+                    raise ContactsBridgeError(
+                        "APPLESCRIPT_OUTPUT_TOO_LARGE",
+                        "AppleScript output exceeded the allowed size.",
+                        "Request fewer contacts and try again.",
+                    )
+                returncode = process.returncode
         except OSError as exc:
             raise ContactsBridgeError(
                 "OSASCRIPT_UNAVAILABLE",
                 f"Could not run 'osascript': {exc}.",
                 "This server requires macOS with osascript available.",
             ) from exc
-        if completed.returncode != 0:
-            raise self._map_script_error(completed.stderr.strip() or completed.stdout.strip())
+        stdout_text = stdout.decode("utf-8", errors="replace")
+        stderr_text = stderr.decode("utf-8", errors="replace")
+        if returncode != 0:
+            raise self._map_script_error(stderr_text.strip() or stdout_text.strip())
 
-        output = completed.stdout.strip()
+        output = stdout_text.strip()
         if not output:
             return {}
         try:
@@ -314,10 +360,18 @@ class AppleContactsBridge:
             )
         return payload
 
-    def _search_contacts_by_name(self, query: str) -> list[ContactSummary]:
+    def _stop_process(self, process: subprocess.Popen[bytes]) -> None:
+        process.terminate()
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+    def _search_contacts_by_name(self, query: str, limit: int) -> list[ContactSummary]:
         if not any(character.isalpha() for character in query):
             return []
-        payload = self._run_script("search_contacts.applescript", query.strip())
+        payload = self._run_script("search_contacts.applescript", query.strip(), str(limit))
         return [self._normalize_summary(item) for item in payload.get("items", []) if isinstance(item, dict)]
 
     def _map_script_error(self, error_text: str) -> ContactsBridgeError:

--- a/AppleContacts-MCP/src/apple_contacts_mcp/tools.py
+++ b/AppleContacts-MCP/src/apple_contacts_mcp/tools.py
@@ -53,7 +53,7 @@ def _resource_json(value: object) -> str:
     annotations=Annotations(audience=["assistant"], priority=0.8),
 )
 def contacts_directory_resource() -> str:
-    contacts = _bridge().list_contacts()[:100]
+    contacts = _bridge().list_contacts(limit=100)
     return _resource_json({"contacts": [item.model_dump() for item in contacts], "count": len(contacts)})
 
 
@@ -156,12 +156,13 @@ def contacts_list_contacts(limit: int = 100, offset: int = 0) -> ContactListResp
     try:
         if limit < 1:
             raise ValueError("limit must be greater than zero")
+        if limit > 100:
+            raise ValueError("limit must not exceed 100")
         if offset < 0:
             raise ValueError("offset must not be negative")
         ensure_action_allowed("contacts_list_contacts")
-        contacts = _bridge().list_contacts()
-        page = contacts[offset : offset + limit]
-        return ContactListResponse(contacts=page, count=len(page))
+        contacts = _bridge().list_contacts(limit=limit, offset=offset)
+        return ContactListResponse(contacts=contacts, count=len(contacts))
     except SafetyError as exc:
         return _error_response(exc.error_code, exc.message, exc.suggestion)
     except ContactsBridgeError as exc:

--- a/AppleContacts-MCP/tests/test_bridge.py
+++ b/AppleContacts-MCP/tests/test_bridge.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from apple_contacts_mcp import contacts_bridge
 from apple_contacts_mcp.contacts_bridge import AppleContactsBridge, ContactsBridgeError
 
 
@@ -43,7 +44,7 @@ def test_search_contacts_prefers_direct_name_search(monkeypatch) -> None:
 
     def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
         assert script_name == "search_contacts.applescript"
-        assert args == ("Sona",)
+        assert args == ("Sona", "25")
         return {
             "items": [
                 {
@@ -85,12 +86,48 @@ def test_get_contact_raises_when_missing(monkeypatch) -> None:
         raise AssertionError("Expected ContactsBridgeError")
 
 
+def test_run_script_times_out_and_terminates_child(monkeypatch, tmp_path) -> None:
+    script_path = tmp_path / "permission_check.applescript"
+    script_path.touch()
+    bridge = AppleContactsBridge(tmp_path)
+    real_popen = subprocess.Popen
+
+    def sleeping_popen(command, **kwargs):
+        return real_popen([sys.executable, "-c", "import time; time.sleep(10)"], **kwargs)
+
+    monkeypatch.setattr(contacts_bridge, "SCRIPT_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(contacts_bridge.subprocess, "Popen", sleeping_popen)
+
+    with pytest.raises(ContactsBridgeError, match="timeout") as exc_info:
+        bridge._run_script(script_path.name)
+
+    assert exc_info.value.error_code == "APPLESCRIPT_TIMEOUT"
+
+
+def test_run_script_rejects_oversized_output(monkeypatch, tmp_path) -> None:
+    script_path = tmp_path / "permission_check.applescript"
+    script_path.touch()
+    bridge = AppleContactsBridge(tmp_path)
+    real_popen = subprocess.Popen
+
+    def noisy_popen(command, **kwargs):
+        return real_popen([sys.executable, "-c", "print('x' * 1024)"], **kwargs)
+
+    monkeypatch.setattr(contacts_bridge, "MAX_SCRIPT_OUTPUT_BYTES", 32)
+    monkeypatch.setattr(contacts_bridge.subprocess, "Popen", noisy_popen)
+
+    with pytest.raises(ContactsBridgeError) as exc_info:
+        bridge._run_script(script_path.name)
+
+    assert exc_info.value.error_code == "APPLESCRIPT_OUTPUT_TOO_LARGE"
+
+
 def test_search_contacts_matches_parenthetical_nickname(monkeypatch) -> None:
     bridge = AppleContactsBridge(Path("/tmp/scripts"))
 
     def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
         assert script_name == "search_contacts.applescript"
-        assert args == ("Sona",) or args == ("Sonali",)
+        assert args == ("Sona", "25") or args == ("Sonali", "25")
         return {
             "items": [
                 {

--- a/AppleContacts-MCP/tests/test_bridge.py
+++ b/AppleContacts-MCP/tests/test_bridge.py
@@ -9,6 +9,28 @@ from apple_contacts_mcp import contacts_bridge
 from apple_contacts_mcp.contacts_bridge import AppleContactsBridge, ContactsBridgeError
 
 
+def contact_item(
+    contact_id: str,
+    *,
+    name: str = "Directory Contact",
+    phone: str = "",
+    email: str = "",
+) -> dict[str, object]:
+    phones = [{"label": "mobile", "value": phone}] if phone else []
+    emails = [{"label": "work", "value": email}] if email else []
+    return {
+        "contact_id": contact_id,
+        "name": name,
+        "first_name": name.split()[0],
+        "last_name": name.split()[-1],
+        "organization": "",
+        "phone_count": len(phones),
+        "email_count": len(emails),
+        "phones": phones,
+        "emails": emails,
+    }
+
+
 def test_search_contacts_matches_phone_number(monkeypatch) -> None:
     bridge = AppleContactsBridge(Path("/tmp/scripts"))
 
@@ -17,6 +39,7 @@ def test_search_contacts_matches_phone_number(monkeypatch) -> None:
             return {"items": []}
         assert script_name == "list_contacts.applescript"
         return {
+            "total": 1,
             "items": [
                 {
                     "contact_id": "contact-1",
@@ -37,6 +60,81 @@ def test_search_contacts_matches_phone_number(monkeypatch) -> None:
 
     assert len(contacts) == 1
     assert contacts[0].contact_id == "contact-1"
+
+
+@pytest.mark.parametrize(
+    ("query", "field", "value"),
+    [
+        ("5550001001", "phone", "+1 (555) 000-1001"),
+        ("late@example.com", "email", "late@example.com"),
+    ],
+)
+def test_search_contacts_scans_past_first_thousand(monkeypatch, query, field, value) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    directory = [contact_item(f"contact-{index}") for index in range(1001)]
+    directory.append(
+        contact_item(
+            "contact-late",
+            name="Late Match",
+            phone=value if field == "phone" else "",
+            email=value if field == "email" else "",
+        )
+    )
+    calls: list[int] = []
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        if script_name == "search_contacts.applescript":
+            return {"items": []}
+        assert script_name == "list_contacts.applescript"
+        limit, offset = map(int, args)
+        calls.append(offset)
+        return {"items": directory[offset : offset + limit], "total": len(directory)}
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    matches = bridge.search_contacts(query)
+
+    assert [contact.contact_id for contact in matches] == ["contact-late"]
+    assert calls == [0, 1000]
+
+
+def test_search_contacts_keeps_exact_matches_before_earlier_partial_matches(monkeypatch) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    directory = [contact_item("contact-partial", phone="+1 555 000 10010")]
+    directory.extend(contact_item(f"contact-{index}") for index in range(1, 1000))
+    directory.append(contact_item("contact-exact", phone="555 000 1001"))
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        limit, offset = map(int, args)
+        return {"items": directory[offset : offset + limit], "total": len(directory)}
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    matches = bridge.search_contacts("5550001001")
+
+    assert [contact.contact_id for contact in matches] == ["contact-exact", "contact-partial"]
+
+
+def test_resolve_recipient_finds_contact_after_first_thousand(monkeypatch) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    directory = [contact_item(f"contact-{index}") for index in range(1001)]
+    late_contact = contact_item("contact-late", name="Late Recipient", phone="+1 555 777 9999")
+    directory.append(late_contact)
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        if script_name == "list_contacts.applescript":
+            limit, offset = map(int, args)
+            return {"items": directory[offset : offset + limit], "total": len(directory)}
+        if script_name == "get_contact.applescript":
+            return {"found": True, "contact": {**late_contact, "note": ""}}
+        raise AssertionError(f"Unexpected script {script_name}")
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    recipient = bridge.resolve_message_recipient("5557779999")
+
+    assert recipient.contact.contact_id == "contact-late"
+    assert recipient.recipient_value == "+1 555 777 9999"
 
 
 def test_search_contacts_prefers_direct_name_search(monkeypatch) -> None:
@@ -102,6 +200,17 @@ def test_run_script_times_out_and_terminates_child(monkeypatch, tmp_path) -> Non
         bridge._run_script(script_path.name)
 
     assert exc_info.value.error_code == "APPLESCRIPT_TIMEOUT"
+
+
+def test_stop_process_handles_exit_before_terminate() -> None:
+    class ExitedProcess:
+        def terminate(self) -> None:
+            raise ProcessLookupError
+
+        def wait(self, timeout=None) -> int:
+            return 0
+
+    AppleContactsBridge(Path("/tmp/scripts"))._stop_process(ExitedProcess())
 
 
 def test_run_script_rejects_oversized_output(monkeypatch, tmp_path) -> None:
@@ -249,6 +358,7 @@ def test_find_duplicates_groups_by_shared_email_and_name(monkeypatch) -> None:
     def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
         if script_name == "list_contacts.applescript":
             return {
+                "total": 2,
                 "items": [
                     {
                         "contact_id": "contact-1",
@@ -286,12 +396,61 @@ def test_find_duplicates_groups_by_shared_email_and_name(monkeypatch) -> None:
     assert {item.kind for item in groups[0].evidence} >= {"name", "email"}
 
 
+def test_find_duplicates_scans_past_first_thousand(monkeypatch) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    directory = [contact_item(f"contact-{index}", name=f"Unique{index}") for index in range(1000)]
+    directory.extend(
+        [
+            contact_item("contact-late-1", name="Late One", email="shared@example.com"),
+            contact_item("contact-late-2", name="Late Two", email="shared@example.com"),
+        ]
+    )
+
+    def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
+        limit, offset = map(int, args)
+        return {"items": directory[offset : offset + limit], "total": len(directory)}
+
+    monkeypatch.setattr(bridge, "_run_script", fake_run_script)
+
+    groups = bridge.find_duplicates()
+
+    assert any(
+        {contact.contact_id for contact in group.contacts} == {"contact-late-1", "contact-late-2"}
+        for group in groups
+    )
+
+
+def test_directory_scan_rejects_total_above_bound(monkeypatch) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    monkeypatch.setattr(
+        bridge,
+        "_run_script",
+        lambda *args: {"items": [], "total": contacts_bridge.MAX_DIRECTORY_CONTACTS + 1},
+    )
+
+    with pytest.raises(ContactsBridgeError) as exc_info:
+        list(bridge._iter_all_contacts())
+
+    assert exc_info.value.error_code == "CONTACT_DIRECTORY_TOO_LARGE"
+
+
+def test_directory_scan_rejects_short_page(monkeypatch) -> None:
+    bridge = AppleContactsBridge(Path("/tmp/scripts"))
+    monkeypatch.setattr(bridge, "_run_script", lambda *args: {"items": [], "total": 1})
+
+    with pytest.raises(ContactsBridgeError) as exc_info:
+        list(bridge._iter_all_contacts())
+
+    assert exc_info.value.error_code == "INCOMPLETE_CONTACT_DIRECTORY"
+
+
 def test_suggest_merge_candidates_filters_query(monkeypatch) -> None:
     bridge = AppleContactsBridge(Path("/tmp/scripts"))
 
     def fake_run_script(script_name: str, *args: str) -> dict[str, object]:
         if script_name == "list_contacts.applescript":
             return {
+                "total": 3,
                 "items": [
                     {
                         "contact_id": "contact-1",

--- a/AppleContacts-MCP/tests/test_tools.py
+++ b/AppleContacts-MCP/tests/test_tools.py
@@ -7,7 +7,7 @@ class FakeBridge:
     def permission_diagnostic(self):
         return True, None
 
-    def list_contacts(self):
+    def list_contacts(self, limit: int = 1000, offset: int = 0):
         return [
             ContactDetail(
                 contact_id="contact-1",
@@ -92,6 +92,27 @@ def test_contacts_resolve_message_recipient_returns_value(monkeypatch) -> None:
 
     assert result.ok is True
     assert result.recipient_value == "+15551234567"
+
+
+def test_contacts_list_enforces_limit_and_passes_pagination_to_bridge(monkeypatch) -> None:
+    calls: list[tuple[int, int]] = []
+
+    class RecordingBridge(FakeBridge):
+        def list_contacts(self, limit: int = 1000, offset: int = 0):
+            calls.append((limit, offset))
+            return super().list_contacts(limit=limit, offset=offset)
+
+    monkeypatch.setenv("APPLE_CONTACTS_MCP_SAFETY_MODE", "safe_readonly")
+    load_settings.cache_clear()
+    monkeypatch.setattr(tools, "_bridge", lambda: RecordingBridge())
+
+    result = tools.contacts_list_contacts(limit=10, offset=20)
+    rejected = tools.contacts_list_contacts(limit=101)
+
+    assert result.ok is True
+    assert calls == [(10, 20)]
+    assert rejected.ok is False
+    assert rejected.error.error_code == "INVALID_INPUT"
 
 
 def test_contacts_create_update_and_delete(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation

- The Contacts bridge executed `osascript` via `subprocess.run` with no timeout or output cap and enumerated the entire address book in-memory, allowing slow or large address books to exhaust CPU/memory or hang the service. 
- Caller-side pagination and search limits were applied after full enumeration, so even small requests could trigger unbounded AppleScript work and large captured output.

### Description

- Add execution guards and limits in the bridge by introducing `SCRIPT_TIMEOUT_SECONDS`, `MAX_SCRIPT_OUTPUT_BYTES`, and `MAX_CONTACTS_PER_REQUEST`, and by switching from `subprocess.run` to a managed `Popen` lifecycle that enforces a deadline, watches output size, and terminates/kills stalled children via `_stop_process`.
- Change `list_contacts` to accept `limit` and `offset` and forward those bounds into the AppleScript, and propagate a bounded limit into name-based direct searches so the bridge no longer requests the entire address book by default. 
- Modify the AppleScripts (`list_contacts.applescript` and `search_contacts.applescript`) to perform native pagination and result-limiting so only the requested slice is serialized by Contacts.app.
- Enforce a maximum caller-facing list limit in the MCP tool (`contacts_list_contacts`) and have the `contacts_directory_resource` request only 100 entries; adjust search plumbing to forward limits to the AppleScript.
- Add regression tests that simulate a sleeping child to trigger the timeout, simulate excessive child output to trigger the size limit, and validate that list-tool limits and pagination are forwarded to the bridge.

### Testing

- Ran `python -m ruff check src tests` with no findings reported by the final run. 
- Ran `python -m pytest -q` and all automated tests passed: `20 passed, 1 skipped`. 
- Added and executed regression tests for timeout, oversized output, and pagination forwarding, and they succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a6a603c2883278591baf0c65b19ba)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound Contacts AppleScript subprocess resource usage with pagination, timeouts, and output limits
> - Adds `limit`/`offset` pagination to the `list_contacts` and `search_contacts` AppleScripts and wires those parameters through `AppleContactsBridge.list_contacts`, `search_contacts`, `_search_contacts_by_name`, and the `contacts_list_contacts` tool (which now rejects limits above 100)
> - Replaces `AppleContactsBridge._run_script` with temp-file capture, monotonic-deadline polling, output-size enforcement, and child-process termination; timed-out runs raise `APPLESCRIPT_TIMEOUT` and oversized output raises `APPLESCRIPT_OUTPUT_TOO_LARGE`, with `_stop_process` escalating to a force kill after a one-second grace period
> - Introduces `AppleContactsBridge._iter_all_contacts` for bounded full-directory scans and routes `search_contacts` fallback matching and `find_duplicates` through it, fixing cases where phone/email matches or duplicates beyond the first page were missed
> - Behavioral Change: bridge methods that previously returned the whole directory now return a single bounded page; full-directory consumers fail with `CONTACT_DIRECTORY_TOO_LARGE`, `INCOMPLETE_CONTACT_DIRECTORY`, or short-page errors instead of silently returning partial results
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37c32f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->