### PR TITLE
Fix AppleScript injection in system notifications by using osascript argv

### DIFF
--- a/AppleSystem-MCP/src/apple_system_mcp/system_bridge.py
+++ b/AppleSystem-MCP/src/apple_system_mcp/system_bridge.py
@@ -213,13 +213,21 @@ class SystemBridge:
         self._run("pbcopy", input_text=text)
 
     def show_notification(self, title: str, body: str, subtitle: str | None = None) -> None:
-        escaped_body = body.replace('"', '\\"')
-        escaped_title = title.replace('"', '\\"')
-        command = [f'display notification "{escaped_body}" with title "{escaped_title}"']
-        if subtitle:
-            escaped_subtitle = subtitle.replace('"', '\\"')
-            command[0] += f' subtitle "{escaped_subtitle}"'
-        self._run("osascript", "-e", command[0])
+        self._run_osascript(
+            [
+                "on run argv",
+                "set notificationBody to item 1 of argv",
+                "set notificationTitle to item 2 of argv",
+                "set notificationSubtitle to item 3 of argv",
+                'if notificationSubtitle is "" then',
+                "display notification notificationBody with title notificationTitle",
+                "else",
+                "display notification notificationBody with title notificationTitle subtitle notificationSubtitle",
+                "end if",
+                "end run",
+            ],
+            args=[body, title, subtitle or ""],
+        )
 
     def open_application(self, application: str | None = None, bundle_id: str | None = None) -> AppRecord:
         if bundle_id and bundle_id.strip():

--- a/AppleSystem-MCP/tests/test_system_bridge.py
+++ b/AppleSystem-MCP/tests/test_system_bridge.py
@@ -34,3 +34,28 @@ def test_context_snapshot_degrades_when_frontmost_lookup_times_out(monkeypatch) 
     assert snapshot["battery"]["percentage"] == 88
     assert snapshot["frontmost_app"] is None
     assert any("Frontmost application unavailable" in note for note in snapshot["notification_history_notes"])
+
+
+def test_show_notification_passes_untrusted_fields_as_osascript_arguments(monkeypatch) -> None:
+    bridge = SystemBridge()
+    captured: list[tuple[str, ...]] = []
+    payload = '\\\"\ndo shell script "unexpected"\n--'
+    monkeypatch.setattr(bridge, "_run", lambda *command: captured.append(command) or "")
+
+    bridge.show_notification(title=payload, body=payload, subtitle=payload)
+
+    command = captured[0]
+    separator = command.index("--")
+    script = command[:separator]
+    assert payload not in script
+    assert command[separator + 1 :] == (payload, payload, payload)
+
+
+def test_show_notification_preserves_optional_subtitle(monkeypatch) -> None:
+    bridge = SystemBridge()
+    captured: list[tuple[str, ...]] = []
+    monkeypatch.setattr(bridge, "_run", lambda *command: captured.append(command) or "")
+
+    bridge.show_notification(title="Title", body="Body")
+
+    assert captured[0][-4:] == ("--", "Body", "Title", "")


### PR DESCRIPTION
### Motivation

- Prevent untrusted notification fields from being interpolated into AppleScript source, which allowed backslash/quote sequences and newlines to inject commands into `osascript -e`.
- Preserve the existing notification capability while eliminating the ability for callers to execute arbitrary AppleScript or shell commands.

### Description

- Replace ad-hoc quote-escaping and inline `osascript -e` source construction in `SystemBridge.show_notification` with a fixed `on run argv` AppleScript handler and pass `body`, `title`, and `subtitle` via `osascript` argv using `self._run_osascript` (changes in `AppleSystem-MCP/src/apple_system_mcp/system_bridge.py`).
- Ensure optional subtitle behavior is preserved by passing an empty string when no subtitle is provided.
- Add regression tests that assert untrusted payloads are passed as `osascript` arguments and do not appear in the executable script, and that notifications without a subtitle still function (changes in `AppleSystem-MCP/tests/test_system_bridge.py`).

### Testing

- ✅ `python -m pytest AppleSystem-MCP/tests` — all tests passed (15 passed).
- ✅ `ruff check AppleSystem-MCP/src AppleSystem-MCP/tests` — lint checks passed.
- ✅ `git diff --check` — no whitespace or diff issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a6a5ead9c8327a82c5d416dfed8ed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix AppleScript injection in `SystemBridge.show_notification`
> Passes notification body, title, and subtitle as positional `osascript` arguments instead of interpolating them into the AppleScript source. Prevents execution of untrusted text containing quotes, newlines, or AppleScript syntax. Adds tests for untrusted field input and optional subtitle handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8ef693.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->