### PR TITLE
Record published v1.0.4 bundle metadata

### DIFF
--- a/Apple-Calendar-MCP/server.json
+++ b/Apple-Calendar-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-calendar-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "e1388cf0e843804b27ba49a3d211a626f928206bd04b25cbccc965983747ab8a",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-calendar-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "594ecdd2dc502b779880a146ca45493cbe380c114097467687d233842cf349ea",
       "transport": {
         "type": "stdio"
       }

--- a/Apple-Tools-MCP/server.json
+++ b/Apple-Tools-MCP/server.json
@@ -148,9 +148,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-tools-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "a491f33f48c98188f416727dfaa3763b63186ded7132dbd6bbe4d511d0998e9f",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-tools-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "b2f06bf0bc7b679be63ff3bbf9b147c9e5ebe6e9206f2ecbd89c35d67827f233",
       "transport": {
         "type": "stdio"
       }

--- a/AppleContacts-MCP/server.json
+++ b/AppleContacts-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-contacts-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "6ca799482cd4a3425bc2da97b773553cf0e9929ae6d2c059959d0651fa32d1a1",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-contacts-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "a9c580ce51603d70cffc1735f2273192fd149204f9cf9593d35ed42a03a2ade2",
       "transport": {
         "type": "stdio"
       }

--- a/AppleFiles-MCP/server.json
+++ b/AppleFiles-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-files-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "d161f4a48fb3ab324a44bcdd0fd4ec50acd27a8d48c622f5c4f2ba9fccf86ee0",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-files-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "b268faf8f1515e3d3bea3ad33756659e7b12647858e33c7e5ab3ec12f41f95bf",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMail-MCP/server.json
+++ b/AppleMail-MCP/server.json
@@ -51,9 +51,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-mail-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "ce9f9f5b982ca4498b003492d9bde8b4992424f52ce807305dc97046076a6661",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-mail-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "2deb90dd2926874b1b8ed5a83f4d1c64163919b714cc6cf325fa5283179305c8",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMaps-MCP/server.json
+++ b/AppleMaps-MCP/server.json
@@ -24,9 +24,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-maps-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "39f547c64b01d8da63e3c0ed21965db268a12db1ace8b50e48528d1b35f29fe0",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-maps-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "54387ba71002ee51f5123d5c4e5aaef1d6efb022fdca413473ba42c95a59c871",
       "transport": {
         "type": "stdio"
       }

--- a/AppleMessages-MCP/server.json
+++ b/AppleMessages-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-messages-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "f51b447329c32216ff98f1f7eb5337bc51e84753fa3bd62c2c967c2f03d34254",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-messages-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "bc3e28e6422bce0b9a6acc5d712ec27c0b2dffbeed5efab825821d470697b95a",
       "transport": {
         "type": "stdio"
       }

--- a/AppleNotes-MCP/server.json
+++ b/AppleNotes-MCP/server.json
@@ -52,9 +52,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-notes-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "c23718d70e4a4dd7fc93c3db4882f4d6af63b46d03659d86f922b1ff3d4e8819",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-notes-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "1054c524a24dcf5bd6f68e8609aebf1ff5841899a42b7d46fa765192183fec5c",
       "transport": {
         "type": "stdio"
       }

--- a/AppleReminders-MCP/server.json
+++ b/AppleReminders-MCP/server.json
@@ -45,9 +45,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-reminders-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "c36be03d9c87a3ceefb720c1b2fcc1fcd6e5b4136c1147750737d6ffe903a279",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-reminders-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "355690c78d298c6feefbb987e8ed7a1b3e8bddbcdbd1e2d190d2bcd6cb4ea170",
       "transport": {
         "type": "stdio"
       }

--- a/AppleShortcuts-MCP/server.json
+++ b/AppleShortcuts-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-shortcuts-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "17863c03bb0ea9289d4b5a6649a52b75c89d0f29c3b0e57197cea307f56ab1bb",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-shortcuts-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "4eefb1d95446d547374df923a325e138fb52660b35faeea1594eacb449f98d55",
       "transport": {
         "type": "stdio"
       }

--- a/AppleSystem-MCP/server.json
+++ b/AppleSystem-MCP/server.json
@@ -38,9 +38,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.3/apple-system-1.0.3.mcpb",
-      "version": "1.0.3",
-      "fileSha256": "bafee0e275a98e596523ab878f153f6f50656ab68467d969f635f90f22bf929c",
+      "identifier": "https://github.com/JonathanRReed/Apple-MCPs/releases/download/v1.0.4/apple-system-1.0.4.mcpb",
+      "version": "1.0.4",
+      "fileSha256": "4c3e50b3d3ebadf4e7a7ff4faca2974045023140429afd51ab010abccf49ecb3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Record the 11 bundle URLs, versions, and SHA-256 hashes from the published v1.0.4 release in the checked-in registry metadata.

Each record was copied from the release asset and checked against the downloaded bundle, SHA256SUMS, and live MCP Registry entry. All 12 PyPI distribution pairs also match the release hashes. No runtime code changed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record published v1.0.4 bundle metadata for Apple MCP services
> - Updates release asset URL, declared version, and SHA-256 checksum from v1.0.3 to v1.0.4 across 11 Apple MCP manifests (Calendar, Tools, Contacts, Files, Mail, Maps, Messages, Notes, Reminders, Shortcuts, System)
> - Manifest consumers now resolve and verify the v1.0.4 release assets
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17001ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->